### PR TITLE
refactor!: replace misc options with preset rules 

### DIFF
--- a/.changeset/clean-ducks-protect.md
+++ b/.changeset/clean-ducks-protect.md
@@ -1,0 +1,7 @@
+---
+"zod-compare": minor
+---
+
+refactor!: replace misc options with middleware
+
+BREAKING CHANGE: The `options` object has been removed and replaced with custom rules.

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,7 +3,8 @@
   "editor.formatOnSaveMode": "file",
   "editor.defaultFormatter": "esbenp.prettier-vscode",
   "editor.codeActionsOnSave": {
-    "source.fixAll": "explicit"
+    "source.fixAll": "explicit",
+    "source.organizeImports": "explicit"
   },
   "testing.automaticallyOpenPeekView": "never"
 }

--- a/src/__tests__/is-same-type.test.ts
+++ b/src/__tests__/is-same-type.test.ts
@@ -189,21 +189,6 @@ describe("isSameType", () => {
 });
 
 describe("isSameType context", () => {
-  test("should context work", () => {
-    const context: CompareContext = {
-      stacks: [],
-    };
-    const result = isSameType(
-      z.object({ name: z.string() }),
-      z.object({ name: z.string() }),
-      context,
-    );
-
-    expect(result).toBe(false);
-    expect(context?.stacks?.length).toEqual(8);
-    expect(context?.stacks?.at(-1)?.name).toEqual("compare ZodObject");
-  });
-
   test("should context work with different primitive type", () => {
     const context: CompareContext = {
       stacks: [],

--- a/src/__tests__/is-same-type.test.ts
+++ b/src/__tests__/is-same-type.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "vitest";
 import { z } from "zod";
 import { isSameType } from "../is-same-type.ts";
-import type { CompareContext } from "../rules.ts";
+import type { CompareContext } from "../types.ts";
 
 describe("isSameType", () => {
   test("should ref same type", () => {

--- a/src/__tests__/is-same-type.test.ts
+++ b/src/__tests__/is-same-type.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "vitest";
 import { z } from "zod";
 import { isSameType } from "../is-same-type.ts";
+import type { CompareContext } from "../rules.ts";
 
 describe("isSameType", () => {
   test("should ref same type", () => {
@@ -184,6 +185,49 @@ describe("isSameType", () => {
       ),
     ).toBe(true);
     expect(isSameType(z.string().readonly(), z.string())).toBe(false);
+  });
+});
+
+describe("isSameType context", () => {
+  test("should context work", () => {
+    const context: CompareContext = {
+      stacks: [],
+    };
+    const result = isSameType(
+      z.object({ name: z.string() }),
+      z.object({ name: z.string() }),
+      context,
+    );
+
+    expect(result).toBe(false);
+    expect(context?.stacks?.length).toEqual(8);
+    expect(context?.stacks?.at(-1)?.name).toEqual("compare ZodObject");
+  });
+
+  test("should context work with different primitive type", () => {
+    const context: CompareContext = {
+      stacks: [],
+    };
+    const result = isSameType(z.number(), z.string(), context);
+
+    expect(result).toBe(false);
+    expect(context?.stacks?.length).toEqual(3);
+    expect(context?.stacks?.at(-1)?.name).toEqual("compare constructor");
+  });
+
+  test("should context work with different type", () => {
+    const context: CompareContext = {
+      stacks: [],
+    };
+    const result = isSameType(
+      z.object({ name: z.number() }),
+      z.object({ name: z.string() }),
+      context,
+    );
+
+    expect(result).toBe(false);
+    expect(context?.stacks?.length).toEqual(11);
+    expect(context?.stacks?.at(-1)?.name).toEqual("compare constructor");
   });
 });
 

--- a/src/__tests__/is-same-type.test.ts
+++ b/src/__tests__/is-same-type.test.ts
@@ -19,6 +19,12 @@ describe("isSameType", () => {
     );
   });
 
+  test("compare any/unknown type", () => {
+    expect(isSameType(z.any(), z.any())).toBe(true);
+    expect(isSameType(z.unknown(), z.unknown())).toBe(true);
+    expect(isSameType(z.any(), z.unknown())).toBe(false);
+  });
+
   test("should return false when compare branded type", () => {
     expect(isSameType(z.string().brand("test"), z.string())).toBe(false);
     expect(isSameType(z.string().brand("test"), z.string().brand("test"))).toBe(
@@ -178,5 +184,44 @@ describe("isSameType", () => {
       ),
     ).toBe(true);
     expect(isSameType(z.string().readonly(), z.string())).toBe(false);
+  });
+});
+
+// See https://zod.dev/?id=coercion-for-primitives
+describe("coerce", () => {
+  test("can compare coerce type", () => {
+    expect(isSameType(z.coerce.string(), z.coerce.number())).toBe(false);
+    expect(isSameType(z.coerce.string(), z.number())).toBe(false);
+    expect(isSameType(z.coerce.string(), z.coerce.string())).toBe(true);
+    expect(isSameType(z.coerce.string(), z.coerce.string())).toBe(true);
+  });
+
+  test("can compare coerce type with normal type", () => {
+    expect(isSameType(z.coerce.string(), z.string())).toBe(true);
+    expect(isSameType(z.coerce.number(), z.number())).toBe(true);
+  });
+
+  test("can compare coerce type with function", () => {
+    expect(
+      isSameType(
+        z
+          .function()
+          .args(z.coerce.number(), z.coerce.string())
+          .returns(z.boolean()),
+        z
+          .function()
+          .args(z.coerce.number(), z.coerce.string())
+          .returns(z.boolean()),
+      ),
+    ).toBe(true);
+    expect(
+      isSameType(
+        z
+          .function()
+          .args(z.coerce.number(), z.coerce.string())
+          .returns(z.boolean()),
+        z.function().args(z.number(), z.string()).returns(z.boolean()),
+      ),
+    ).toBe(true);
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
 export { isCompatibleType } from "./is-compatible-type.ts";
 export { createIsSameTypeFn, isSameType } from "./is-same-type.ts";
-export { defineRule, isSameTypePresetRules } from "./rules.ts";
+export { defineCompareRule, isSameTypePresetRules } from "./rules.ts";
 export type { IsSameTypeOptions } from "./utils.ts";

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
 export { isCompatibleType } from "./is-compatible-type.ts";
 export { createIsSameTypeFn, isSameType } from "./is-same-type.ts";
 export { defineCompareRule, isSameTypePresetRules } from "./rules.ts";
-export type { IsSameTypeOptions } from "./utils.ts";
+export type * from "./types.ts";

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
-export { isSameType } from "./is-same-type.ts";
 export { isCompatibleType } from "./is-compatible-type.ts";
+export { createIsSameTypeFn, isSameType } from "./is-same-type.ts";
+export { defineRule, isSameTypePresetRules } from "./rules.ts";
 export type { IsSameTypeOptions } from "./utils.ts";

--- a/src/is-compatible-type.ts
+++ b/src/is-compatible-type.ts
@@ -28,6 +28,9 @@ import {
 export const isCompatibleType = (
   higherType: ZodType,
   lowerType: ZodType,
+  /**
+   * @deprecated Options will be removed in the future
+   */
   options?: Partial<IsCompatibleTypeOptions>,
 ): boolean => {
   const opts: IsCompatibleTypeOptions = {
@@ -38,7 +41,7 @@ export const isCompatibleType = (
   if (interceptorResult === true || interceptorResult === false) {
     return interceptorResult;
   }
-  if (isSameType(higherType, lowerType, opts)) {
+  if (isSameType(higherType, lowerType)) {
     return true;
   }
 

--- a/src/is-compatible-type.ts
+++ b/src/is-compatible-type.ts
@@ -1,10 +1,6 @@
 import { z, type ZodType } from "zod";
 import { isSameType } from "./is-same-type.ts";
-import {
-  DEFAULT_COMPARE_TYPE_OPTIONS,
-  flatUnwrapUnion,
-  type IsCompatibleTypeOptions,
-} from "./utils.ts";
+import { flatUnwrapUnion } from "./utils.ts";
 
 /**
  * Check if a the higherType matches the lowerType
@@ -28,19 +24,7 @@ import {
 export const isCompatibleType = (
   higherType: ZodType,
   lowerType: ZodType,
-  /**
-   * @deprecated Options will be removed in the future
-   */
-  options?: Partial<IsCompatibleTypeOptions>,
 ): boolean => {
-  const opts: IsCompatibleTypeOptions = {
-    ...DEFAULT_COMPARE_TYPE_OPTIONS,
-    ...options,
-  };
-  const interceptorResult = opts.interceptor(higherType, lowerType, opts);
-  if (interceptorResult === true || interceptorResult === false) {
-    return interceptorResult;
-  }
   if (isSameType(higherType, lowerType)) {
     return true;
   }
@@ -55,7 +39,7 @@ export const isCompatibleType = (
     lowerType instanceof z.ZodOptional ||
     lowerType instanceof z.ZodNullable
   ) {
-    return isCompatibleType(higherType, lowerType.unwrap(), opts);
+    return isCompatibleType(higherType, lowerType.unwrap());
   }
 
   // ZodUnion aka or
@@ -64,7 +48,7 @@ export const isCompatibleType = (
     const lowerOptions = flatUnwrapUnion(lowerType);
     for (let i = 0; i < higherOptions.length; i++) {
       const match = lowerOptions.some((option: ZodType) =>
-        isCompatibleType(higherOptions[i], option, opts),
+        isCompatibleType(higherOptions[i], option),
       );
       if (!match) return false;
     }
@@ -73,13 +57,13 @@ export const isCompatibleType = (
   if (higherType instanceof z.ZodUnion) {
     const higherOptions = flatUnwrapUnion(higherType);
     return higherOptions.every((option: ZodType) =>
-      isCompatibleType(option, lowerType, opts),
+      isCompatibleType(option, lowerType),
     );
   }
   if (lowerType instanceof z.ZodUnion) {
     const lowerOptions = flatUnwrapUnion(lowerType);
     return lowerOptions.some((option: ZodType) =>
-      isCompatibleType(higherType, option, opts),
+      isCompatibleType(higherType, option),
     );
   }
 
@@ -96,7 +80,7 @@ export const isCompatibleType = (
       return false;
     for (const key in subTypeShape) {
       if (!(key in superTypeShape)) return false;
-      if (!isCompatibleType(superTypeShape[key], subTypeShape[key], opts)) {
+      if (!isCompatibleType(superTypeShape[key], subTypeShape[key])) {
         return false;
       }
     }
@@ -105,21 +89,21 @@ export const isCompatibleType = (
 
   // ZodArray
   if (higherType instanceof z.ZodArray && lowerType instanceof z.ZodArray) {
-    return isCompatibleType(higherType.element, lowerType.element, opts);
+    return isCompatibleType(higherType.element, lowerType.element);
   }
 
   // ZodTuple
   if (higherType instanceof z.ZodTuple && lowerType instanceof z.ZodTuple) {
     if (higherType.items.length < lowerType.items.length) return false;
     for (let i = 0; i < lowerType.items.length; i++) {
-      if (!isCompatibleType(higherType.items[i], lowerType.items[i], opts)) {
+      if (!isCompatibleType(higherType.items[i], lowerType.items[i])) {
         return false;
       }
     }
     // Check rest
     if (lowerType._def.rest) {
       if (!higherType._def.rest) return false;
-      return isCompatibleType(higherType._def.rest, lowerType._def.rest, opts);
+      return isCompatibleType(higherType._def.rest, lowerType._def.rest);
     }
     return true;
   }

--- a/src/is-same-type.ts
+++ b/src/is-same-type.ts
@@ -1,11 +1,47 @@
-import type { EnumLike, ZodType } from "zod";
-import { z } from "zod";
+import type { ZodType } from "zod";
 import {
-  type IsSameTypeOptions,
-  DEFAULT_COMPARE_TYPE_OPTIONS,
-  isPrimitiveType,
-  flatUnwrapUnion,
-} from "./utils.ts";
+  isSameTypePresetRules,
+  type CompareContext,
+  type CompareRule,
+} from "./rules.ts";
+
+export const createIsSameTypeFn = (rules: CompareRule[]) => {
+  const isSameTypeFn = (
+    a: ZodType,
+    b: ZodType,
+    context: CompareContext = {},
+  ): boolean => {
+    let prevIndex = -1;
+    const runner = (index: number): boolean => {
+      if (index === rules.length) {
+        throw new Error("Failed to compare type! " + a + " " + b);
+      }
+      if (index === prevIndex) {
+        throw new Error("next() called multiple times");
+      }
+      prevIndex = index;
+      const rule = rules[index];
+
+      if ("stacks" in context && Array.isArray(context.stacks)) {
+        context.stacks.push({
+          name: rule.name,
+          target: [a, b],
+        });
+      }
+
+      return rule.compare(
+        a,
+        b,
+        () => runner(index + 1),
+        (a, b) => isSameTypeFn(a, b, context),
+        context,
+      );
+    };
+
+    return runner(0);
+  };
+  return isSameTypeFn;
+};
 
 /**
  * isSameType is a function that checks if two ZodTypes are the same.
@@ -13,7 +49,6 @@ import {
  * Caveats:
  * - The function does not validate specific criteria such as min or max values, length, email, etc.
  * - It excludes comparisons involving methods like .describe(), .catch(), .default(), .refine(), and .transform().
- * - When comparing definitions with .or and .and, they are assessed sequentially based on their order.
  *
  * @param a - The first ZodType to compare.
  * @param b - The second ZodType to compare.
@@ -27,193 +62,4 @@ import {
  * isSameType(z.string(), z.number()); // false
  * ```
  */
-export const isSameType = (
-  a: ZodType,
-  b: ZodType,
-  options?: Partial<IsSameTypeOptions>,
-): boolean => {
-  const opts = { ...DEFAULT_COMPARE_TYPE_OPTIONS, ...options };
-  const interceptorResult = opts.interceptor(a, b, opts);
-  if (interceptorResult === true || interceptorResult === false) {
-    return interceptorResult;
-  }
-
-  if (a === undefined || b === undefined) {
-    throw new Error("Failed to compare type! " + a + " " + b);
-  }
-
-  if (a === b) {
-    return true;
-  }
-
-  // compare constructor
-  if (a.constructor !== b.constructor) {
-    // https://stackoverflow.com/questions/24959862/how-to-tell-if-two-javascript-instances-are-of-the-same-class-type
-    return false;
-  }
-  // See https://github.com/colinhacks/zod/blob/master/src/types.ts
-  if (!("typeName" in a._def) || !("typeName" in b._def)) {
-    throw new Error("Failed to compare type! " + a._def + " " + b._def);
-  }
-  if (a._def.typeName !== b._def.typeName) {
-    return false;
-  }
-
-  // ZodBranded
-  if (opts.ignoreBranded) {
-    if (a instanceof z.ZodBranded) {
-      a = a.unwrap();
-    }
-    if (b instanceof z.ZodBranded) {
-      b = b.unwrap();
-    }
-    return isSameType(a, b, opts);
-  } else {
-    if (a instanceof z.ZodBranded || b instanceof z.ZodBranded) {
-      // We can not distinguish different branded type
-      // throw new Error("Can not distinguish different branded type!");
-      return false;
-    }
-  }
-
-  // ZodPromise ZodOptional ZodNullable ZodBranded
-  if ("unwrap" in a && typeof a.unwrap === "function") {
-    if (!("unwrap" in b && typeof b.unwrap === "function")) {
-      return false;
-    }
-    return isSameType(a.unwrap(), b.unwrap(), opts);
-  }
-
-  if (!opts.ignoreOptional && a.isOptional() !== b.isOptional()) return false;
-  if (!opts.ignoreNullable && a.isNullable() !== b.isNullable()) return false;
-
-  if (isPrimitiveType(a)) {
-    // Already assert a and b are the same constructor
-    return true;
-  }
-
-  // ZodObject
-  if (a instanceof z.ZodObject && b instanceof z.ZodObject) {
-    const aShape = a.shape;
-    const bShape = b.shape;
-    if (Object.keys(aShape).length !== Object.keys(bShape).length) return false;
-    for (const key in aShape) {
-      if (!(key in bShape)) return false;
-      if (!isSameType(aShape[key], bShape[key], opts)) return false;
-    }
-    return true;
-  }
-
-  // ZodArray
-  if (a instanceof z.ZodArray && b instanceof z.ZodArray) {
-    return isSameType(a.element, b.element, opts);
-  }
-
-  // ZodTuple
-  if (a instanceof z.ZodTuple && b instanceof z.ZodTuple) {
-    if (a.items.length !== b.items.length) return false;
-    for (let i = 0; i < a.items.length; i++) {
-      if (!isSameType(a.items[i], b.items[i], opts)) return false;
-    }
-    // Compare rest
-    if (a._def.rest || b._def.rest) {
-      // If one has rest, the other must have rest
-      if (!a._def.rest || !b._def.rest) return false;
-      return isSameType(a._def.rest, b._def.rest, opts);
-    }
-    return true;
-  }
-
-  // ZodLiteral
-  if (a instanceof z.ZodLiteral && b instanceof z.ZodLiteral) {
-    return a.value === b.value;
-  }
-
-  // ZodIntersection aka and
-  if (a instanceof z.ZodIntersection && b instanceof z.ZodIntersection) {
-    return (
-      (isSameType(a._def.left, b._def.left, opts) &&
-        isSameType(a._def.right, b._def.right, opts)) ||
-      (isSameType(a._def.left, b._def.right, opts) &&
-        isSameType(a._def.right, b._def.left, opts))
-    );
-  }
-
-  // ZodUnion aka or
-  if (a instanceof z.ZodUnion && b instanceof z.ZodUnion) {
-    const aOptions = flatUnwrapUnion(a as z.ZodUnion<z.ZodUnionOptions>);
-    const bOptions = flatUnwrapUnion(b as z.ZodUnion<z.ZodUnionOptions>);
-    if (aOptions.length !== bOptions.length) return false;
-
-    for (let optionA of aOptions) {
-      let matchIndex = bOptions.findIndex((optionB) =>
-        isSameType(optionA, optionB, opts),
-      );
-      if (matchIndex === -1) return false;
-      bOptions.splice(matchIndex, 1);
-    }
-
-    return bOptions.length === 0;
-  }
-
-  // ZodReadonly
-  if (a instanceof z.ZodReadonly && b instanceof z.ZodReadonly) {
-    return isSameType(a._def.innerType, b._def.innerType, opts);
-  }
-
-  // ZodRecord / ZodMap
-  if (
-    (a instanceof z.ZodRecord && b instanceof z.ZodRecord) ||
-    (a instanceof z.ZodMap && b instanceof z.ZodMap)
-  ) {
-    return (
-      isSameType(a.keySchema, b.keySchema, opts) &&
-      isSameType(a.valueSchema, b.valueSchema, opts)
-    );
-  }
-
-  // ZodSet
-  if (a instanceof z.ZodSet && b instanceof z.ZodSet) {
-    return isSameType(a._def.valueType, b._def.valueType, opts);
-  }
-
-  // ZodFunction
-  if (a instanceof z.ZodFunction && b instanceof z.ZodFunction) {
-    return (
-      isSameType(a.parameters(), b.parameters(), opts) &&
-      isSameType(a.returnType(), b.returnType(), opts)
-    );
-  }
-
-  // ZodEnum
-  if (a instanceof z.ZodEnum && b instanceof z.ZodEnum) {
-    const optionsA: [string, ...string[]] = a.options;
-    const optionsB: [string, ...string[]] = b.options;
-    if (optionsA.length !== optionsB.length) return false;
-    for (let i = 0; i < optionsA.length; i++) {
-      if (optionsA[i] !== optionsB[i]) return false;
-    }
-    return true;
-  }
-
-  // ZodNativeEnum
-  if (a instanceof z.ZodNativeEnum && b instanceof z.ZodNativeEnum) {
-    const enumA: EnumLike = a.enum;
-    const enumB: EnumLike = b.enum;
-    if (Object.keys(enumA).length !== Object.keys(enumB).length) return false;
-    for (const key in enumA) {
-      if (enumA[key] !== enumB[key]) return false;
-    }
-    return true;
-  }
-
-  // ZodLazy
-  // ZodEffects
-  // ZodDefault
-  // ZodCatch
-  // ZodPipeline
-  // ZodTransformer
-  // ZodError
-  console.error('Failed to compare type! "' + a, b);
-  throw new Error("Unknown type! " + a._def.typeName + " " + b._def.typeName);
-};
+export const isSameType = createIsSameTypeFn(isSameTypePresetRules);

--- a/src/is-same-type.ts
+++ b/src/is-same-type.ts
@@ -1,9 +1,6 @@
 import type { ZodType } from "zod";
-import {
-  isSameTypePresetRules,
-  type CompareContext,
-  type CompareRule,
-} from "./rules.ts";
+import { isSameTypePresetRules } from "./rules.ts";
+import { type CompareContext, type CompareRule } from "./types.ts";
 
 export const createIsSameTypeFn = (rules: CompareRule[]) => {
   const isSameTypeFn = (

--- a/src/rules.ts
+++ b/src/rules.ts
@@ -1,0 +1,315 @@
+import { z, type ZodType } from "zod";
+import { flatUnwrapUnion, isPrimitiveType } from "./utils.ts";
+
+export type CompareContext = {
+  stacks?: {
+    name: string;
+    target: [a: ZodType, b: ZodType];
+  }[];
+} & Record<string, unknown>;
+
+type CompareFn = (
+  a: ZodType,
+  b: ZodType,
+  next: () => boolean,
+  recheck: (a: ZodType, b: ZodType) => boolean,
+  context: CompareContext,
+) => boolean;
+
+export type CompareRule = {
+  name: string;
+  compare: CompareFn;
+};
+
+export const defineRule = (name: string, rule: CompareFn) => ({
+  name,
+  rule,
+});
+
+export const isSameTypePresetRules = [
+  {
+    name: "undefined check",
+    compare: (a, b, next) => {
+      if (a === undefined || b === undefined) {
+        throw new Error("Failed to compare type! " + a + " " + b);
+      }
+      return next();
+    },
+  },
+  {
+    name: "compare reference",
+    compare: (a, b, next) => {
+      if (a === b) {
+        return true;
+      }
+      return next();
+    },
+  },
+  {
+    name: "compare constructor",
+    compare: (a, b, next) => {
+      // https://stackoverflow.com/questions/24959862/how-to-tell-if-two-javascript-instances-are-of-the-same-class-type
+      if (a.constructor !== b.constructor) {
+        return false;
+      }
+      return next();
+    },
+  },
+  {
+    name: "compare typeName",
+    compare: (a, b, next) => {
+      if (!("typeName" in a._def) || !("typeName" in b._def)) {
+        throw new Error("Failed to compare type! " + a._def + " " + b._def);
+      }
+      if (a._def.typeName !== b._def.typeName) {
+        return false;
+      }
+      return next();
+    },
+  },
+  {
+    name: "compare ZodBranded",
+    compare: (a, b, next) => {
+      if (a instanceof z.ZodBranded || b instanceof z.ZodBranded) {
+        // We can not distinguish different branded type
+        // throw new Error("Can not distinguish different branded type!");
+        return false;
+      }
+      return next();
+    },
+  },
+  {
+    name: "unwrap ZodType",
+    // ZodPromise ZodOptional ZodNullable ZodBranded
+    compare: (a, b, next, recheck) => {
+      if ("unwrap" in a && typeof a.unwrap === "function") {
+        if (!("unwrap" in b && typeof b.unwrap === "function")) {
+          return false;
+        }
+        return recheck(a.unwrap(), b.unwrap());
+      }
+      return next();
+    },
+  },
+  {
+    name: "is same primitive",
+    compare: (a, b, next) => {
+      if (
+        isPrimitiveType(a) &&
+        isPrimitiveType(b) &&
+        a.constructor === b.constructor
+      ) {
+        return true;
+      }
+      return next();
+    },
+  },
+  {
+    name: "compare ZodObject",
+    compare: (a, b, next, recheck) => {
+      if (a instanceof z.ZodObject && b instanceof z.ZodObject) {
+        const aShape = a.shape;
+        const bShape = b.shape;
+        if (Object.keys(aShape).length !== Object.keys(bShape).length)
+          return false;
+        for (const key in aShape) {
+          if (!(key in bShape)) return false;
+          if (!recheck(aShape[key], bShape[key])) return false;
+        }
+        return true;
+      }
+      return next();
+    },
+  },
+  {
+    name: "compare ZodArray",
+    compare: (a, b, next, recheck) => {
+      if (a instanceof z.ZodArray && b instanceof z.ZodArray) {
+        return recheck(a.element, b.element);
+      }
+      return next();
+    },
+  },
+  {
+    name: "compare ZodTuple",
+    compare: (a, b, next, recheck) => {
+      if (a instanceof z.ZodTuple && b instanceof z.ZodTuple) {
+        if (a.items.length !== b.items.length) return false;
+        for (let i = 0; i < a.items.length; i++) {
+          if (!recheck(a.items[i], b.items[i])) return false;
+        }
+        // Compare rest
+        if (a._def.rest || b._def.rest) {
+          // If one has rest, the other must have rest
+          if (!a._def.rest || !b._def.rest) return false;
+          return recheck(a._def.rest, b._def.rest);
+        }
+        return true;
+      }
+      return next();
+    },
+  },
+  {
+    name: "compare ZodLiteral",
+    compare: (a, b, next) => {
+      if (a instanceof z.ZodLiteral && b instanceof z.ZodLiteral) {
+        return a.value === b.value;
+      }
+      return next();
+    },
+  },
+  {
+    name: "compare ZodIntersection",
+    compare: (a, b, next, recheck) => {
+      // ZodIntersection aka and
+      if (a instanceof z.ZodIntersection && b instanceof z.ZodIntersection) {
+        return (
+          (recheck(a._def.left, b._def.left) &&
+            recheck(a._def.right, b._def.right)) ||
+          (recheck(a._def.left, b._def.right) &&
+            recheck(a._def.right, b._def.left))
+        );
+      }
+      return next();
+    },
+  },
+  {
+    name: "compare ZodUnion",
+    compare: (a, b, next, recheck) => {
+      // ZodUnion aka or
+      if (a instanceof z.ZodUnion && b instanceof z.ZodUnion) {
+        const aOptions = flatUnwrapUnion(a as z.ZodUnion<z.ZodUnionOptions>);
+        const bOptions = flatUnwrapUnion(b as z.ZodUnion<z.ZodUnionOptions>);
+        if (aOptions.length !== bOptions.length) return false;
+        for (let optionA of aOptions) {
+          let matchIndex = bOptions.findIndex((optionB) =>
+            recheck(optionA, optionB),
+          );
+          if (matchIndex === -1) return false;
+          bOptions.splice(matchIndex, 1);
+        }
+        return bOptions.length === 0;
+      }
+      return next();
+    },
+  },
+  {
+    name: "compare ZodReadonly",
+    compare: (a, b, next, recheck) => {
+      if (a instanceof z.ZodReadonly && b instanceof z.ZodReadonly) {
+        return recheck(a._def.innerType, b._def.innerType);
+      }
+      return next();
+    },
+  },
+  {
+    name: "compare ZodRecord",
+    compare: (a, b, next, recheck) => {
+      if (a instanceof z.ZodRecord && b instanceof z.ZodRecord) {
+        return (
+          recheck(a.keySchema, b.keySchema) &&
+          recheck(a.valueSchema, b.valueSchema)
+        );
+      }
+      return next();
+    },
+  },
+  {
+    name: "compare ZodMap",
+    compare: (a, b, next, recheck) => {
+      if (a instanceof z.ZodMap && b instanceof z.ZodMap) {
+        return (
+          recheck(a.keySchema, b.keySchema) &&
+          recheck(a.valueSchema, b.valueSchema)
+        );
+      }
+      return next();
+    },
+  },
+  {
+    name: "compare ZodSet",
+    compare: (a, b, next, recheck) => {
+      if (a instanceof z.ZodSet && b instanceof z.ZodSet) {
+        return recheck(a._def.valueType, b._def.valueType);
+      }
+      return next();
+    },
+  },
+  {
+    name: "compare ZodFunction",
+    compare: (a, b, next, recheck) => {
+      if (a instanceof z.ZodFunction && b instanceof z.ZodFunction) {
+        return (
+          recheck(a.parameters(), b.parameters()) &&
+          recheck(a.returnType(), b.returnType())
+        );
+      }
+      return next();
+    },
+  },
+  {
+    name: "compare ZodEnum",
+    compare: (a, b, next) => {
+      if (a instanceof z.ZodEnum && b instanceof z.ZodEnum) {
+        const optionsA: [string, ...string[]] = a.options;
+        const optionsB: [string, ...string[]] = b.options;
+        if (optionsA.length !== optionsB.length) return false;
+        for (let i = 0; i < optionsA.length; i++) {
+          if (optionsA[i] !== optionsB[i]) return false;
+        }
+        return true;
+      }
+      return next();
+    },
+  },
+  {
+    name: "compare ZodNativeEnum",
+    compare: (a, b, next) => {
+      if (a instanceof z.ZodNativeEnum && b instanceof z.ZodNativeEnum) {
+        const enumA: z.EnumLike = a.enum;
+        const enumB: z.EnumLike = b.enum;
+        if (Object.keys(enumA).length !== Object.keys(enumB).length)
+          return false;
+        for (const key in enumA) {
+          if (enumA[key] !== enumB[key]) return false;
+        }
+        return true;
+      }
+      return next();
+    },
+  },
+] as const satisfies CompareRule[];
+
+export const strictIsSameTypeRules = [
+  {
+    name: "compare optional",
+    compare: (a, b, next) => {
+      if (a.isOptional() !== b.isOptional()) return false;
+      return next();
+    },
+  },
+  {
+    name: "compare nullable",
+    compare: (a, b, next) => {
+      if (a.isNullable() !== b.isNullable()) return false;
+      return next();
+    },
+  },
+  {
+    name: "compare corece",
+    compare: (a, b, next) => {
+      if ("corece" in a._def && "corece" in b._def) {
+        if (a._def.corece !== b._def.corece) {
+          return false;
+        }
+      }
+      if ("corece" in a._def) {
+        return false;
+      }
+      if ("corece" in b._def) {
+        return false;
+      }
+      return next();
+    },
+  },
+] as const satisfies CompareRule[];

--- a/src/rules.ts
+++ b/src/rules.ts
@@ -21,7 +21,7 @@ export type CompareRule = {
   compare: CompareFn;
 };
 
-export const defineRule = (name: string, rule: CompareFn) => ({
+export const defineCompareRule = (name: string, rule: CompareFn) => ({
   name,
   rule,
 });
@@ -307,6 +307,15 @@ export const strictIsSameTypeRules = [
         return false;
       }
       if ("corece" in b._def) {
+        return false;
+      }
+      return next();
+    },
+  },
+  {
+    name: "compare description",
+    compare: (a, b, next) => {
+      if (a.description !== b.description) {
         return false;
       }
       return next();

--- a/src/rules.ts
+++ b/src/rules.ts
@@ -1,25 +1,6 @@
-import { z, type ZodType } from "zod";
+import { z } from "zod";
+import type { CompareFn, CompareRule } from "./types.ts";
 import { flatUnwrapUnion, isPrimitiveType } from "./utils.ts";
-
-export type CompareContext = {
-  stacks?: {
-    name: string;
-    target: [a: ZodType, b: ZodType];
-  }[];
-} & Record<string, unknown>;
-
-type CompareFn = (
-  a: ZodType,
-  b: ZodType,
-  next: () => boolean,
-  recheck: (a: ZodType, b: ZodType) => boolean,
-  context: CompareContext,
-) => boolean;
-
-export type CompareRule = {
-  name: string;
-  compare: CompareFn;
-};
 
 export const defineCompareRule = (name: string, rule: CompareFn) => ({
   name,

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,21 @@
+import { type ZodType } from "zod";
+
+export type CompareContext = {
+  stacks?: {
+    name: string;
+    target: [a: ZodType, b: ZodType];
+  }[];
+} & Record<string, unknown>;
+
+export type CompareFn = (
+  a: ZodType,
+  b: ZodType,
+  next: () => boolean,
+  recheck: (a: ZodType, b: ZodType) => boolean,
+  context: CompareContext,
+) => boolean;
+
+export type CompareRule = {
+  name: string;
+  compare: CompareFn;
+};

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,46 +1,5 @@
 import { z, type ZodType } from "zod";
 
-export interface IsSameTypeOptions {
-  deep: true;
-  /**
-   * Ignore all specific validations like min, max, length, email etc.
-   *
-   * You still can use `interceptor` to validate the type manually.
-   */
-  ignoreValidations: true;
-  ignoreOptional: boolean;
-  ignoreNullable: boolean;
-  ignoreReadOnly: false;
-  ignoreBranded: boolean;
-  /**
-   * A function that provides custom logic for comparing two ZodType instances.
-   *
-   * If the function returns `true` or `false`, the result will be used as the comparison result.
-   * Otherwise, the default comparison logic will be used.
-   *
-   */
-  interceptor: (
-    a: ZodType,
-    b: ZodType,
-    options: IsSameTypeOptions,
-  ) => boolean | void;
-}
-
-export interface IsCompatibleTypeOptions extends IsSameTypeOptions {
-  ignoreOptional: false;
-  ignoreNullable: false;
-}
-
-export const DEFAULT_COMPARE_TYPE_OPTIONS = {
-  deep: true,
-  ignoreOptional: false,
-  ignoreNullable: false,
-  ignoreReadOnly: false,
-  ignoreBranded: false,
-  ignoreValidations: true,
-  interceptor: () => {},
-} as const satisfies IsSameTypeOptions;
-
 // See ZodFirstPartyTypeKind
 export const isPrimitiveType = (a: ZodType): boolean => {
   return (


### PR DESCRIPTION
Fix https://github.com/lawvs/zod-compare/issues/5

## BREAKE CHANGE

The legacy `options` have been removed from `isSameType` and replaced with custom rules.
