### PR TITLE
fix: align isCompatibleType expected provided semantics

### DIFF
--- a/.changeset/is-compatible-type-assignability.md
+++ b/.changeset/is-compatible-type-assignability.md
@@ -1,0 +1,7 @@
+---
+"zod-compare": minor
+---
+
+Update `isCompatibleType` to use the `(expectedType, providedType)` assignability model and improve TypeScript-like compatibility checks for optional and nullable wrappers, unions, finite literal and enum values, arrays, tuples, objects, records, maps, and sets.
+
+Document that Zod 4 brands are type-only and compare like their underlying runtime schema.

--- a/README.md
+++ b/README.md
@@ -172,6 +172,10 @@ expectTypeOf<z.infer<typeof providedType>>().toExtend<
 If TypeScript accepts this assignment, `isCompatibleType(expectedType,
 providedType)` should return `true` for the supported Zod schema kinds.
 
+`isCompatibleType` can only compare schema information available at runtime.
+Zod 4 brands are type-only, so branded schemas compare like their underlying
+runtime schema.
+
 ### Preset Rules
 
 You can use the preset rules `isSameTypePresetRules` and `isCompatibleTypePresetRules` to create custom comparison functions.

--- a/README.md
+++ b/README.md
@@ -152,15 +152,16 @@ In subtype-order terminology, `expectedType` is the higher type and
 `z.object({ name, other }) <= z.object({ name })`, so the wider `{ name }`
 schema can be used as the expected type.
 
-A useful TypeScript type-test mental model is:
+A useful TypeScript type-check-only mental model is:
 
 ```ts
-expectTypeOf<z.infer<typeof providedType>>().toExtend<
-  z.infer<typeof expectedType>
->();
+declare const provided: z.infer<typeof providedType>;
+type Expected = z.infer<typeof expectedType>;
+
+const expected: Expected = provided;
 ```
 
-If TypeScript accepts this relationship, `isCompatibleType(expectedType,
+If TypeScript accepts this assignment, `isCompatibleType(expectedType,
 providedType)` should return `true` for the supported Zod schema kinds.
 
 ### Preset Rules

--- a/README.md
+++ b/README.md
@@ -161,6 +161,14 @@ type Expected = z.infer<typeof expectedType>;
 const expected: Expected = provided;
 ```
 
+In a Vitest type test, the same relationship can be written as:
+
+```ts
+expectTypeOf<z.infer<typeof providedType>>().toExtend<
+  z.infer<typeof expectedType>
+>();
+```
+
 If TypeScript accepts this assignment, `isCompatibleType(expectedType,
 providedType)` should return `true` for the supported Zod schema kinds.
 

--- a/README.md
+++ b/README.md
@@ -152,6 +152,16 @@ In subtype-order terminology, `expectedType` is the higher type and
 `z.object({ name, other }) <= z.object({ name })`, so the wider `{ name }`
 schema can be used as the expected type.
 
+A useful TypeScript mental model is:
+
+```ts
+const provided = null as unknown as z.infer<typeof providedType>;
+const expected: z.infer<typeof expectedType> = provided;
+```
+
+If TypeScript accepts this assignment, `isCompatibleType(expectedType,
+providedType)` should return `true` for the supported Zod schema kinds.
+
 ### Preset Rules
 
 You can use the preset rules `isSameTypePresetRules` and `isCompatibleTypePresetRules` to create custom comparison functions.

--- a/README.md
+++ b/README.md
@@ -152,14 +152,15 @@ In subtype-order terminology, `expectedType` is the higher type and
 `z.object({ name, other }) <= z.object({ name })`, so the wider `{ name }`
 schema can be used as the expected type.
 
-A useful TypeScript mental model is:
+A useful TypeScript type-test mental model is:
 
 ```ts
-const provided = null as unknown as z.infer<typeof providedType>;
-const expected: z.infer<typeof expectedType> = provided;
+expectTypeOf<z.infer<typeof providedType>>().toExtend<
+  z.infer<typeof expectedType>
+>();
 ```
 
-If TypeScript accepts this assignment, `isCompatibleType(expectedType,
+If TypeScript accepts this relationship, `isCompatibleType(expectedType,
 providedType)` should return `true` for the supported Zod schema kinds.
 
 ### Preset Rules

--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ isSameType(
 // false
 
 isCompatibleType(
-  z.object({ name: z.string(), other: z.number() }),
   z.object({ name: z.string() }),
+  z.object({ name: z.string(), other: z.number() }),
 );
 // true
 ```
@@ -44,7 +44,7 @@ isCompatibleType(
 Use the top-level helpers to compare schemas:
 
 - `isSameType(a, b)`: true only if the two schemas have the same shape and types (ignores refinements like min/max/length, transforms, etc.)
-- `isCompatibleType(higherType, lowerType)`: true if the looser schema (higherType) can be accepted wherever the stricter schema (lowerType) is expected
+- `isCompatibleType(expectedType, providedType)`: true if every value described by `providedType` is assignable to `expectedType` (`providedType <= expectedType`)
 
 ## Advanced Usage
 
@@ -137,10 +137,20 @@ Compares two Zod schemas and returns `true` if they are compatible.
 
 ```ts
 import { isCompatibleType } from "zod-compare";
-// The `higherType` should be a looser type
-// The `lowerType` should be a stricter type
-type isCompatibleType: (higherType: $ZodType, lowerType: $ZodType) => boolean;
+// The `expectedType` should be the wider/supertype schema.
+// The `providedType` should be the narrower/subtype schema.
+// Returns true when providedType <= expectedType.
+type isCompatibleType: (
+  expectedType: $ZodType,
+  providedType: $ZodType,
+  context?: CompareContext,
+) => boolean;
 ```
+
+In subtype-order terminology, `expectedType` is the higher type and
+`providedType` is the lower type. For example,
+`z.object({ name, other }) <= z.object({ name })`, so the wider `{ name }`
+schema can be used as the expected type.
 
 ### Preset Rules
 

--- a/src/zod4/__tests__/is-compatible-type.test.ts
+++ b/src/zod4/__tests__/is-compatible-type.test.ts
@@ -26,6 +26,31 @@ describe("isCompatibleType", () => {
     expect(isCompatibleType(z.undefined(), z.void())).toBe(false);
     expect(isCompatibleType(z.number(), z.nan())).toBe(true);
     expect(isCompatibleType(z.nan(), z.number())).toBe(true);
+    expect(isCompatibleType(z.string().optional(), z.literal(undefined))).toBe(
+      true,
+    );
+    expect(isCompatibleType(z.string().nullable(), z.literal(null))).toBe(true);
+    expect(
+      isCompatibleType(
+        z.string().optional(),
+        z.union([z.string(), z.undefined()]),
+      ),
+    ).toBe(true);
+    expect(
+      isCompatibleType(
+        z.string().optional(),
+        z.union([z.string(), z.number(), z.undefined()]),
+      ),
+    ).toBe(false);
+    expect(
+      isCompatibleType(z.string().nullable(), z.union([z.string(), z.null()])),
+    ).toBe(true);
+    expect(
+      isCompatibleType(
+        z.string().nullable(),
+        z.union([z.string(), z.number(), z.null()]),
+      ),
+    ).toBe(false);
   });
 
   test("does not treat promise inner nullish types as outer nullish values", () => {
@@ -253,6 +278,24 @@ describe("isCompatibleType", () => {
       isCompatibleType(
         z.record(z.string(), z.string()),
         z.record(z.number(), z.string()),
+      ),
+    ).toBe(true);
+    expect(
+      isCompatibleType(
+        z.record(z.enum(["a"]), z.string()),
+        z.record(z.enum(["a", "b"]), z.string()),
+      ),
+    ).toBe(true);
+    expect(
+      isCompatibleType(
+        z.record(z.enum(["a", "b"]), z.string()),
+        z.record(z.enum(["a"]), z.string()),
+      ),
+    ).toBe(false);
+    expect(
+      isCompatibleType(
+        z.record(z.enum(["a"]), z.string()),
+        z.record(z.string(), z.string()),
       ),
     ).toBe(true);
 

--- a/src/zod4/__tests__/is-compatible-type.test.ts
+++ b/src/zod4/__tests__/is-compatible-type.test.ts
@@ -3,141 +3,250 @@ import { z } from "zod/v4";
 import { isCompatibleType } from "../is-compatible-type.ts";
 
 describe("isCompatibleType", () => {
-  test("should ref same type", () => {
+  test("returns true for the same schema reference", () => {
     const uniqueType = z.string().brand("unique");
     expect(isCompatibleType(uniqueType, uniqueType)).toBe(true);
   });
 
-  test("compare basic type", () => {
+  test("compares primitive and wrapper assignability", () => {
     expect(isCompatibleType(z.undefined(), z.undefined())).toBe(true);
     expect(isCompatibleType(z.string(), z.string())).toBe(true);
-    expect(isCompatibleType(z.string(), z.number())).toBe(false);
-    expect(isCompatibleType(z.string().optional(), z.string())).toBe(false);
+    expect(isCompatibleType(z.number(), z.string())).toBe(false);
+    expect(isCompatibleType(z.string(), z.string().optional())).toBe(false);
+    expect(isCompatibleType(z.string().optional(), z.string())).toBe(true);
     expect(isCompatibleType(z.string().optional(), z.string().optional())).toBe(
       true,
     );
-    expect(isCompatibleType(z.string().nullable(), z.string().optional())).toBe(
+    expect(isCompatibleType(z.string().optional(), z.string().nullable())).toBe(
       false,
     );
-    expect(isCompatibleType(z.string(), z.string().nullable())).toBe(true);
-    expect(isCompatibleType(z.string(), z.string().optional())).toBe(true);
+    expect(isCompatibleType(z.string().nullable(), z.string())).toBe(true);
+    expect(isCompatibleType(z.string(), z.string().nullable())).toBe(false);
   });
 
-  test("should compare simple object", () => {
+  test("compares TypeScript top, bottom, and any-like schemas", () => {
+    expect(isCompatibleType(z.unknown(), z.string())).toBe(true);
+    expect(isCompatibleType(z.string(), z.unknown())).toBe(false);
+
+    expect(isCompatibleType(z.string(), z.never())).toBe(true);
+    expect(isCompatibleType(z.never(), z.string())).toBe(false);
+
+    expect(isCompatibleType(z.any(), z.string())).toBe(true);
+    expect(isCompatibleType(z.string(), z.any())).toBe(true);
+    expect(isCompatibleType(z.never(), z.any())).toBe(false);
+  });
+
+  test("compares object assignability with width subtyping", () => {
     expect(
       isCompatibleType(
+        z.object({
+          name: z.string(),
+        }),
         z.object({
           name: z.string(),
           other: z.number(),
         }),
-        z.object({
-          name: z.string(),
-        }),
       ),
     ).toBe(true);
     expect(
       isCompatibleType(
-        z.object({
-          name: z.number(),
-        }),
         z.object({
           name: z.number().nullable(),
         }),
+        z.object({
+          name: z.number(),
+        }),
       ),
     ).toBe(true);
     expect(
       isCompatibleType(
+        z.object({
+          name: z.string(),
+        }),
         z
           .object({
             name: z.string().optional(),
           })
           .partial(),
-        z.object({
-          name: z.string(),
-        }),
       ),
     ).toBe(false);
     expect(
       isCompatibleType(
-        z.object({
-          name: z.string(),
-        }),
         z
           .object({
             name: z.string(),
           })
           .partial(),
+        z.object({
+          name: z.string(),
+        }),
       ),
     ).toBe(true);
+    expect(
+      isCompatibleType(
+        z.object({
+          name: z.string().optional(),
+        }),
+        z.object({
+          name: z.string().nullable(),
+        }),
+      ),
+    ).toBe(false);
+    expect(
+      isCompatibleType(
+        z.object({
+          name: z.string(),
+        }),
+        z.object({}),
+      ),
+    ).toBe(false);
+  });
+
+  test("allows missing provided keys when expected keys are optional", () => {
+    expect(
+      isCompatibleType(
+        z.object({
+          name: z.string().optional(),
+        }),
+        z.object({}),
+      ),
+    ).toBe(true);
+
     expect(
       isCompatibleType(
         z.object({
           name: z.string().nullable(),
         }),
+        z.object({}),
+      ),
+    ).toBe(false);
+
+    expect(
+      isCompatibleType(
         z.object({
           name: z.string().optional(),
         }),
-      ),
-    ).toBe(false);
-    expect(
-      isCompatibleType(
-        z.object({}),
         z.object({
           name: z.string(),
         }),
       ),
-    ).toBe(false);
+    ).toBe(true);
   });
 
-  test("should compare rest tuple", () => {
+  test("compares tuple assignability", () => {
     expect(
       isCompatibleType(
         z.tuple([z.string(), z.string()]),
         z.tuple([z.string()]),
       ),
-    ).toBe(true);
+    ).toBe(false);
+
     expect(
       isCompatibleType(
+        z.tuple([z.string(), z.number()]),
         z.tuple([z.string(), z.string()]),
+      ),
+    ).toBe(false);
+
+    expect(
+      isCompatibleType(
+        z.tuple([z.string()]).rest(z.number()),
+        z.tuple([z.string()]),
+      ),
+    ).toBe(true);
+
+    expect(
+      isCompatibleType(
+        z.tuple([z.string()]).rest(z.number()),
         z.tuple([z.string(), z.number()]),
       ),
-    ).toBe(false);
+    ).toBe(true);
+
     expect(
       isCompatibleType(
-        z.tuple([z.string(), z.string()]).rest(z.number()),
+        z.tuple([z.string()]).rest(z.number()),
         z.tuple([z.string(), z.string()]),
       ),
-    ).toBe(true);
-    expect(
-      isCompatibleType(
-        z.tuple([z.string()]),
-        z.tuple([z.string()]).rest(z.number()),
-      ),
     ).toBe(false);
+
+    expect(
+      isCompatibleType(z.array(z.number()), z.tuple([]).rest(z.number())),
+    ).toBe(true);
 
     expect(
       isCompatibleType(z.tuple([]).rest(z.number()), z.array(z.number())),
-    ).toBe(false);
+    ).toBe(true);
   });
 
-  test("should compare `or` type", () => {
-    expect(isCompatibleType(z.string(), z.string().or(z.number()))).toBe(true);
+  test("compares union assignability", () => {
+    expect(isCompatibleType(z.string().or(z.number()), z.string())).toBe(true);
     expect(
-      isCompatibleType(z.string(), z.number().or(z.string()).or(z.boolean())),
+      isCompatibleType(z.number().or(z.string()).or(z.boolean()), z.string()),
     ).toBe(true);
-    expect(isCompatibleType(z.string().or(z.number()), z.string())).toBe(false);
+    expect(isCompatibleType(z.string(), z.string().or(z.number()))).toBe(false);
     expect(
       isCompatibleType(
-        z.string().or(z.number()),
         z.number().or(z.string()).or(z.boolean()),
+        z.string().or(z.number()),
       ),
     ).toBe(true);
 
-    expect(isCompatibleType(z.string().or(z.boolean()), z.string())).toBe(
+    expect(isCompatibleType(z.string(), z.string().or(z.boolean()))).toBe(
       false,
     );
     expect(
-      isCompatibleType(z.string().or(z.boolean()), z.string().or(z.number())),
+      isCompatibleType(z.string().or(z.number()), z.string().or(z.boolean())),
     ).toBe(false);
+  });
+
+  test("compares record map and set assignability", () => {
+    expect(
+      isCompatibleType(
+        z.record(z.string(), z.unknown()),
+        z.record(z.string(), z.string()),
+      ),
+    ).toBe(true);
+    expect(
+      isCompatibleType(
+        z.record(z.string(), z.string()),
+        z.record(z.string(), z.unknown()),
+      ),
+    ).toBe(false);
+
+    expect(
+      isCompatibleType(
+        z.map(z.string(), z.unknown()),
+        z.map(z.string(), z.string()),
+      ),
+    ).toBe(true);
+    expect(
+      isCompatibleType(
+        z.map(z.string(), z.string()),
+        z.map(z.string(), z.unknown()),
+      ),
+    ).toBe(false);
+
+    expect(isCompatibleType(z.set(z.unknown()), z.set(z.string()))).toBe(true);
+    expect(isCompatibleType(z.set(z.string()), z.set(z.unknown()))).toBe(false);
+  });
+
+  test("compares enum and literal subset assignability", () => {
+    expect(isCompatibleType(z.literal("a"), z.literal("a"))).toBe(true);
+    expect(
+      isCompatibleType(z.literal("a").or(z.literal("b")), z.literal("a")),
+    ).toBe(true);
+    expect(isCompatibleType(z.literal("a"), z.literal("b"))).toBe(false);
+
+    expect(isCompatibleType(z.enum(["a", "b"]), z.enum(["a"]))).toBe(true);
+    expect(isCompatibleType(z.enum(["a"]), z.enum(["a", "b"]))).toBe(false);
+
+    expect(isCompatibleType(z.enum(["a", "b"]), z.literal("a"))).toBe(true);
+    expect(isCompatibleType(z.literal("a"), z.enum(["a", "b"]))).toBe(false);
+
+    expect(isCompatibleType(z.string(), z.literal("a"))).toBe(true);
+    expect(isCompatibleType(z.string(), z.enum(["a", "b"]))).toBe(true);
+    expect(isCompatibleType(z.number(), z.literal(1))).toBe(true);
+    expect(isCompatibleType(z.boolean(), z.literal(true))).toBe(true);
+    expect(isCompatibleType(z.literal("a"), z.string())).toBe(false);
   });
 });

--- a/src/zod4/__tests__/is-compatible-type.test.ts
+++ b/src/zod4/__tests__/is-compatible-type.test.ts
@@ -22,6 +22,10 @@ describe("isCompatibleType", () => {
     );
     expect(isCompatibleType(z.string().nullable(), z.string())).toBe(true);
     expect(isCompatibleType(z.string(), z.string().nullable())).toBe(false);
+    expect(isCompatibleType(z.void(), z.undefined())).toBe(true);
+    expect(isCompatibleType(z.undefined(), z.void())).toBe(false);
+    expect(isCompatibleType(z.number(), z.nan())).toBe(true);
+    expect(isCompatibleType(z.nan(), z.number())).toBe(true);
   });
 
   test("does not treat promise inner nullish types as outer nullish values", () => {
@@ -133,6 +137,24 @@ describe("isCompatibleType", () => {
     expect(
       isCompatibleType(
         z.object({
+          name: z.union([z.string(), z.undefined()]),
+        }),
+        z.object({}),
+      ),
+    ).toBe(false);
+
+    expect(
+      isCompatibleType(
+        z.object({
+          name: z.undefined(),
+        }),
+        z.object({}),
+      ),
+    ).toBe(false);
+
+    expect(
+      isCompatibleType(
+        z.object({
           name: z.string().optional(),
         }),
         z.object({
@@ -221,6 +243,18 @@ describe("isCompatibleType", () => {
         z.record(z.string(), z.unknown()),
       ),
     ).toBe(false);
+    expect(
+      isCompatibleType(
+        z.record(z.number(), z.string()),
+        z.record(z.string(), z.string()),
+      ),
+    ).toBe(true);
+    expect(
+      isCompatibleType(
+        z.record(z.string(), z.string()),
+        z.record(z.number(), z.string()),
+      ),
+    ).toBe(true);
 
     expect(
       isCompatibleType(
@@ -240,6 +274,11 @@ describe("isCompatibleType", () => {
   });
 
   test("compares enum and literal subset assignability", () => {
+    enum NumericEnum {
+      A,
+      B,
+    }
+
     expect(isCompatibleType(z.literal("a"), z.literal("a"))).toBe(true);
     expect(
       isCompatibleType(z.literal("a").or(z.literal("b")), z.literal("a")),
@@ -251,6 +290,9 @@ describe("isCompatibleType", () => {
 
     expect(isCompatibleType(z.enum(["a", "b"]), z.literal("a"))).toBe(true);
     expect(isCompatibleType(z.literal("a"), z.enum(["a", "b"]))).toBe(false);
+    expect(isCompatibleType(z.number(), z.enum(NumericEnum))).toBe(true);
+    expect(isCompatibleType(z.enum(NumericEnum), z.literal(0))).toBe(true);
+    expect(isCompatibleType(z.literal(0), z.enum(NumericEnum))).toBe(false);
 
     expect(isCompatibleType(z.string(), z.literal("a"))).toBe(true);
     expect(isCompatibleType(z.string(), z.enum(["a", "b"]))).toBe(true);

--- a/src/zod4/__tests__/is-compatible-type.test.ts
+++ b/src/zod4/__tests__/is-compatible-type.test.ts
@@ -24,6 +24,15 @@ describe("isCompatibleType", () => {
     expect(isCompatibleType(z.string(), z.string().nullable())).toBe(false);
   });
 
+  test("does not treat promise inner nullish types as outer nullish values", () => {
+    expect(isCompatibleType(z.string().nullable(), z.promise(z.null()))).toBe(
+      false,
+    );
+    expect(
+      isCompatibleType(z.string().optional(), z.promise(z.undefined())),
+    ).toBe(false);
+  });
+
   test("compares TypeScript top, bottom, and any-like schemas", () => {
     expect(isCompatibleType(z.unknown(), z.string())).toBe(true);
     expect(isCompatibleType(z.string(), z.unknown())).toBe(false);

--- a/src/zod4/is-compatible-type.ts
+++ b/src/zod4/is-compatible-type.ts
@@ -4,7 +4,7 @@ import { isSameType } from "./is-same-type.ts";
 import type { CompareRule } from "./types.ts";
 import { flatUnwrapUnion, isZodType, isZodTypes } from "./utils.ts";
 
-type PrimitiveKind = "undefined" | "null";
+type NullishKind = "undefined" | "null";
 
 const getInnerType = (schema: $ZodTypes): $ZodTypes | undefined => {
   const def = schema._zod.def;
@@ -19,15 +19,15 @@ const getInnerType = (schema: $ZodTypes): $ZodTypes | undefined => {
   return undefined;
 };
 
-const schemaAcceptsPrimitiveKind = (
+const schemaAcceptsNullishKind = (
   schema: $ZodType,
-  primitiveKind: PrimitiveKind,
+  nullishKind: NullishKind,
 ): boolean => {
   if (!isZodType(schema) || !isZodTypes(schema)) return false;
 
   const def = schema._zod.def;
   if (
-    def.type === primitiveKind ||
+    def.type === nullishKind ||
     def.type === "any" ||
     def.type === "unknown"
   ) {
@@ -35,24 +35,20 @@ const schemaAcceptsPrimitiveKind = (
   }
 
   if (def.type === "optional") {
-    if (primitiveKind === "undefined") return true;
+    if (nullishKind === "undefined") return true;
     const innerType = getInnerType(schema);
-    return innerType
-      ? schemaAcceptsPrimitiveKind(innerType, primitiveKind)
-      : false;
+    return innerType ? schemaAcceptsNullishKind(innerType, nullishKind) : false;
   }
 
   if (def.type === "nullable") {
-    if (primitiveKind === "null") return true;
+    if (nullishKind === "null") return true;
     const innerType = getInnerType(schema);
-    return innerType
-      ? schemaAcceptsPrimitiveKind(innerType, primitiveKind)
-      : false;
+    return innerType ? schemaAcceptsNullishKind(innerType, nullishKind) : false;
   }
 
   if (def.type === "union") {
     return flatUnwrapUnion(schema as $ZodUnion).some((option) =>
-      schemaAcceptsPrimitiveKind(option, primitiveKind),
+      schemaAcceptsNullishKind(option, nullishKind),
     );
   }
 
@@ -151,7 +147,7 @@ export const isCompatibleTypePresetRules: CompareRule[] = [
           providedDef.type === "optional" ? "undefined" : "null";
         return (
           recheck(expectedType, innerType) &&
-          schemaAcceptsPrimitiveKind(expectedType, primitiveKind)
+          schemaAcceptsNullishKind(expectedType, primitiveKind)
         );
       }
       return next();
@@ -168,7 +164,7 @@ export const isCompatibleTypePresetRules: CompareRule[] = [
           expectedDef.type === "optional" ? "undefined" : "null";
         return (
           recheck(innerType, providedType) ||
-          schemaAcceptsPrimitiveKind(providedType, primitiveKind)
+          schemaAcceptsNullishKind(providedType, primitiveKind)
         );
       }
       return next();
@@ -271,7 +267,7 @@ export const isCompatibleTypePresetRules: CompareRule[] = [
         const providedShape = providedType._zod.def.shape;
         for (const key in expectedShape) {
           if (!(key in providedShape)) {
-            if (!schemaAcceptsPrimitiveKind(expectedShape[key], "undefined")) {
+            if (!schemaAcceptsNullishKind(expectedShape[key], "undefined")) {
               return false;
             }
             continue;

--- a/src/zod4/is-compatible-type.ts
+++ b/src/zod4/is-compatible-type.ts
@@ -153,24 +153,6 @@ const primitiveKindAcceptsValue = (
   }
 };
 
-const primitiveKindsAreCompatible = (
-  expectedKind: $ZodTypes["_zod"]["def"]["type"],
-  providedKind: $ZodTypes["_zod"]["def"]["type"],
-): boolean | undefined => {
-  if (expectedKind === "void" && providedKind === "undefined") {
-    return true;
-  }
-
-  if (
-    (expectedKind === "number" || expectedKind === "nan") &&
-    (providedKind === "number" || providedKind === "nan")
-  ) {
-    return true;
-  }
-
-  return undefined;
-};
-
 const recordKeysAreCompatible = (
   expectedKeyType: $ZodType,
   providedKeyType: $ZodType,
@@ -329,11 +311,21 @@ export const isCompatibleTypePresetRules: CompareRule[] = [
   {
     name: "check primitive assignability",
     compare: (expectedType, providedType, next) => {
-      const result = primitiveKindsAreCompatible(
-        expectedType._zod.def.type,
-        providedType._zod.def.type,
-      );
-      return result ?? next();
+      const expectedKind = expectedType._zod.def.type;
+      const providedKind = providedType._zod.def.type;
+
+      if (expectedKind === "void" && providedKind === "undefined") {
+        return true;
+      }
+
+      if (
+        (expectedKind === "number" || expectedKind === "nan") &&
+        (providedKind === "number" || providedKind === "nan")
+      ) {
+        return true;
+      }
+
+      return next();
     },
   },
   {

--- a/src/zod4/is-compatible-type.ts
+++ b/src/zod4/is-compatible-type.ts
@@ -1,14 +1,109 @@
-import type { $ZodUnion } from "zod/v4/core";
+import type { $ZodType, $ZodTypes, $ZodUnion } from "zod/v4/core";
 import { createCompareFn } from "./create-compare-fn.ts";
 import { isSameType } from "./is-same-type.ts";
 import type { CompareRule } from "./types.ts";
-import { flatUnwrapUnion, isZodType } from "./utils.ts";
+import { flatUnwrapUnion, isZodType, isZodTypes } from "./utils.ts";
+
+type PrimitiveKind = "undefined" | "null";
+
+const getInnerType = (schema: $ZodTypes): $ZodTypes | undefined => {
+  const def = schema._zod.def;
+  if (
+    "innerType" in def &&
+    typeof def.innerType === "object" &&
+    isZodType(def.innerType) &&
+    isZodTypes(def.innerType)
+  ) {
+    return def.innerType;
+  }
+  return undefined;
+};
+
+const schemaAcceptsPrimitiveKind = (
+  schema: $ZodType,
+  primitiveKind: PrimitiveKind,
+): boolean => {
+  if (!isZodType(schema) || !isZodTypes(schema)) return false;
+
+  const def = schema._zod.def;
+  if (
+    def.type === primitiveKind ||
+    def.type === "any" ||
+    def.type === "unknown"
+  ) {
+    return true;
+  }
+
+  if (def.type === "optional") {
+    if (primitiveKind === "undefined") return true;
+    const innerType = getInnerType(schema);
+    return innerType
+      ? schemaAcceptsPrimitiveKind(innerType, primitiveKind)
+      : false;
+  }
+
+  if (def.type === "nullable") {
+    if (primitiveKind === "null") return true;
+    const innerType = getInnerType(schema);
+    return innerType
+      ? schemaAcceptsPrimitiveKind(innerType, primitiveKind)
+      : false;
+  }
+
+  if (def.type === "union") {
+    return flatUnwrapUnion(schema as $ZodUnion).some((option) =>
+      schemaAcceptsPrimitiveKind(option, primitiveKind),
+    );
+  }
+
+  return false;
+};
+
+const getFiniteLiteralValues = (
+  schema: $ZodTypes,
+): readonly unknown[] | undefined => {
+  const def = schema._zod.def;
+  if (def.type === "literal") {
+    return def.values as readonly unknown[];
+  }
+  if (def.type === "enum") {
+    return Object.values(def.entries as Record<string, unknown>);
+  }
+  return undefined;
+};
+
+const primitiveKindAcceptsValue = (
+  primitiveKind: $ZodTypes["_zod"]["def"]["type"],
+  value: unknown,
+): boolean => {
+  switch (primitiveKind) {
+    case "string":
+      return typeof value === "string";
+    case "number":
+      return typeof value === "number" && !Number.isNaN(value);
+    case "bigint":
+      return typeof value === "bigint";
+    case "boolean":
+      return typeof value === "boolean";
+    case "symbol":
+      return typeof value === "symbol";
+    case "undefined":
+    case "void":
+      return value === undefined;
+    case "null":
+      return value === null;
+    case "nan":
+      return typeof value === "number" && Number.isNaN(value);
+    default:
+      return false;
+  }
+};
 
 export const isCompatibleTypePresetRules: CompareRule[] = [
   {
     name: "is same type",
-    compare: (higherType, lowerType, next) => {
-      if (isSameType(higherType, lowerType)) {
+    compare: (expectedType, providedType, next) => {
+      if (isSameType(expectedType, providedType)) {
         return true;
       }
       return next();
@@ -16,82 +111,172 @@ export const isCompatibleTypePresetRules: CompareRule[] = [
   },
   {
     name: "check typeName",
-    compare: (higherType, lowerType, next) => {
-      // In Zod4, type information is in _zod.def
+    compare: (expectedType, providedType, next) => {
       if (
-        !("_zod" in higherType) ||
-        !("def" in higherType._zod) ||
-        !("_zod" in lowerType) ||
-        !("def" in lowerType._zod)
+        !isZodType(expectedType) ||
+        !isZodTypes(expectedType) ||
+        !isZodType(providedType) ||
+        !isZodTypes(providedType)
       ) {
         throw new Error(
-          "Failed to compare type! " + higherType + " " + lowerType,
+          "Failed to compare type! " + expectedType + " " + providedType,
         );
       }
       return next();
     },
   },
   {
-    name: "check optional/nullable on lower",
-    compare: (higherType, lowerType, next, recheck) => {
-      const lowerDef = lowerType._zod.def;
-      if (
-        (lowerDef.type === "optional" || lowerDef.type === "nullable") &&
-        "innerType" in lowerDef &&
-        typeof lowerDef.innerType === "object" &&
-        isZodType(lowerDef.innerType)
-      ) {
-        return recheck(higherType, lowerDef.innerType);
+    name: "check top bottom and any",
+    compare: (expectedType, providedType, next) => {
+      const expectedKind = expectedType._zod.def.type;
+      const providedKind = providedType._zod.def.type;
+
+      if (providedKind === "never") return true;
+      if (expectedKind === "any" || expectedKind === "unknown") return true;
+      if (expectedKind === "never") return false;
+      if (providedKind === "unknown") return false;
+      if (providedKind === "any") return true;
+
+      return next();
+    },
+  },
+  {
+    name: "check optional/nullable on provided",
+    compare: (expectedType, providedType, next, recheck) => {
+      const providedDef = providedType._zod.def;
+      if (providedDef.type === "optional" || providedDef.type === "nullable") {
+        const innerType = getInnerType(providedType);
+        if (!innerType) return false;
+        const primitiveKind =
+          providedDef.type === "optional" ? "undefined" : "null";
+        return (
+          recheck(expectedType, innerType) &&
+          schemaAcceptsPrimitiveKind(expectedType, primitiveKind)
+        );
+      }
+      return next();
+    },
+  },
+  {
+    name: "check optional/nullable on expected",
+    compare: (expectedType, providedType, next, recheck) => {
+      const expectedDef = expectedType._zod.def;
+      if (expectedDef.type === "optional" || expectedDef.type === "nullable") {
+        const innerType = getInnerType(expectedType);
+        if (!innerType) return false;
+        const primitiveKind =
+          expectedDef.type === "optional" ? "undefined" : "null";
+        return (
+          recheck(innerType, providedType) ||
+          schemaAcceptsPrimitiveKind(providedType, primitiveKind)
+        );
       }
       return next();
     },
   },
   {
     name: "check union",
-    compare: (higherType, lowerType, next, recheck) => {
-      const aType = higherType._zod.def.type;
-      const bType = lowerType._zod.def.type;
-      if (aType === "union" && bType === "union") {
-        const aOpts = flatUnwrapUnion(higherType as $ZodUnion);
-        const bOpts = flatUnwrapUnion(lowerType as $ZodUnion);
-        // Every option in higher must be accepted by at least one option in lower
-        return aOpts.every((optA) => bOpts.some((optB) => recheck(optA, optB)));
+    compare: (expectedType, providedType, next, recheck) => {
+      const expectedKind = expectedType._zod.def.type;
+      const providedKind = providedType._zod.def.type;
+      if (expectedKind === "union" && providedKind === "union") {
+        const expectedOptions = flatUnwrapUnion(expectedType as $ZodUnion);
+        const providedOptions = flatUnwrapUnion(providedType as $ZodUnion);
+        return providedOptions.every((providedOption) =>
+          expectedOptions.some((expectedOption) =>
+            recheck(expectedOption, providedOption),
+          ),
+        );
       }
-      if (aType === "union") {
-        const aOpts = flatUnwrapUnion(higherType as $ZodUnion);
-        // All options from higher must be compatible with the (non-union) lower
-        return aOpts.every((opt) => recheck(opt, lowerType));
+      if (expectedKind === "union") {
+        const expectedOptions = flatUnwrapUnion(expectedType as $ZodUnion);
+        return expectedOptions.some((expectedOption) =>
+          recheck(expectedOption, providedType),
+        );
       }
-      if (bType === "union") {
-        const bOpts = flatUnwrapUnion(lowerType as $ZodUnion);
-        // Higher must match at least one option in lower
-        return bOpts.some((opt) => recheck(higherType, opt));
+      if (providedKind === "union") {
+        const providedOptions = flatUnwrapUnion(providedType as $ZodUnion);
+        return providedOptions.every((providedOption) =>
+          recheck(expectedType, providedOption),
+        );
       }
+      return next();
+    },
+  },
+  {
+    name: "check finite literal values",
+    compare: (expectedType, providedType, next) => {
+      const expectedValues = getFiniteLiteralValues(expectedType);
+      const providedValues = getFiniteLiteralValues(providedType);
+      if (!expectedValues && providedValues) {
+        const expectedKind = expectedType._zod.def.type;
+        if (
+          providedValues.every((value) =>
+            primitiveKindAcceptsValue(expectedKind, value),
+          )
+        ) {
+          return true;
+        }
+      }
+      if (expectedValues || providedValues) {
+        if (!expectedValues || !providedValues) return next();
+        const expectedSet = new Set(expectedValues);
+        return providedValues.every((value) => expectedSet.has(value));
+      }
+      return next();
+    },
+  },
+  {
+    name: "check array tuple cross compatibility",
+    compare: (expectedType, providedType, next, recheck) => {
+      const expectedKind = expectedType._zod.def.type;
+      const providedKind = providedType._zod.def.type;
+
+      if (expectedKind === "array" && providedKind === "tuple") {
+        const expectedElement = expectedType._zod.def.element;
+        const providedItems = providedType._zod.def.items;
+        for (const item of providedItems) {
+          if (!recheck(expectedElement, item)) return false;
+        }
+        const providedRest = providedType._zod.def.rest;
+        return providedRest ? recheck(expectedElement, providedRest) : true;
+      }
+
+      if (expectedKind === "tuple" && providedKind === "array") {
+        const expectedItems = expectedType._zod.def.items;
+        const expectedRest = expectedType._zod.def.rest;
+        if (expectedItems.length > 0 || !expectedRest) return false;
+        return recheck(expectedRest, providedType._zod.def.element);
+      }
+
       return next();
     },
   },
   {
     name: "compare type by kind",
-    compare: (higherType, lowerType, next) => {
-      const aTypeName = higherType._zod.def.type;
-      const bTypeName = lowerType._zod.def.type;
-      if (aTypeName !== bTypeName) return false;
+    compare: (expectedType, providedType, next) => {
+      const expectedKind = expectedType._zod.def.type;
+      const providedKind = providedType._zod.def.type;
+      if (expectedKind !== providedKind) return false;
       return next();
     },
   },
   {
-    name: "check object (structural subset)",
-    compare: (higherType, lowerType, next, recheck) => {
-      const aType = higherType._zod.def.type;
-      const bType = lowerType._zod.def.type;
-      if (aType === "object" && bType === "object") {
-        const superShape = higherType._zod.def.shape;
-        const subShape = lowerType._zod.def.shape;
-        if (Object.keys(superShape).length < Object.keys(subShape).length)
-          return false;
-        for (const key in subShape) {
-          if (!(key in superShape)) return false;
-          if (!recheck(superShape[key], subShape[key])) return false;
+    name: "check object (structural assignability)",
+    compare: (expectedType, providedType, next, recheck) => {
+      const expectedKind = expectedType._zod.def.type;
+      const providedKind = providedType._zod.def.type;
+      if (expectedKind === "object" && providedKind === "object") {
+        const expectedShape = expectedType._zod.def.shape;
+        const providedShape = providedType._zod.def.shape;
+        for (const key in expectedShape) {
+          if (!(key in providedShape)) {
+            if (!schemaAcceptsPrimitiveKind(expectedShape[key], "undefined")) {
+              return false;
+            }
+            continue;
+          }
+          if (!recheck(expectedShape[key], providedShape[key])) return false;
         }
         return true;
       }
@@ -100,56 +285,126 @@ export const isCompatibleTypePresetRules: CompareRule[] = [
   },
   {
     name: "check array",
-    compare: (higherType, lowerType, next, recheck) => {
-      const aType = higherType._zod.def.type;
-      const bType = lowerType._zod.def.type;
-      if (aType === "array" && bType === "array") {
-        return recheck(higherType._zod.def.element, lowerType._zod.def.element);
+    compare: (expectedType, providedType, next, recheck) => {
+      const expectedKind = expectedType._zod.def.type;
+      const providedKind = providedType._zod.def.type;
+      if (expectedKind === "array" && providedKind === "array") {
+        return recheck(
+          expectedType._zod.def.element,
+          providedType._zod.def.element,
+        );
       }
       return next();
     },
   },
   {
     name: "check tuple (length and rest)",
-    compare: (higherType, lowerType, next, recheck) => {
-      const aType = higherType._zod.def.type;
-      const bType = lowerType._zod.def.type;
-      if (aType === "tuple" && bType === "tuple") {
-        const aItems = higherType._zod.def.items;
-        const bItems = lowerType._zod.def.items;
-        if (aItems.length < bItems.length) return false;
-        for (let i = 0; i < bItems.length; i++) {
-          if (!recheck(aItems[i], bItems[i])) return false;
+    compare: (expectedType, providedType, next, recheck) => {
+      const expectedKind = expectedType._zod.def.type;
+      const providedKind = providedType._zod.def.type;
+      if (expectedKind === "tuple" && providedKind === "tuple") {
+        const expectedItems = expectedType._zod.def.items;
+        const providedItems = providedType._zod.def.items;
+        const expectedRest = expectedType._zod.def.rest;
+        const providedRest = providedType._zod.def.rest;
+
+        if (providedItems.length < expectedItems.length) return false;
+        for (let i = 0; i < expectedItems.length; i++) {
+          if (!recheck(expectedItems[i], providedItems[i])) return false;
         }
-        // If lower has rest, higher must have rest and be compatible
-        const aRest = higherType._zod.def.rest;
-        const bRest = lowerType._zod.def.rest;
-        if (bRest) {
-          if (!aRest) return false;
-          return recheck(aRest, bRest);
+        if (providedItems.length > expectedItems.length) {
+          if (!expectedRest) return false;
+          for (let i = expectedItems.length; i < providedItems.length; i++) {
+            if (!recheck(expectedRest, providedItems[i])) return false;
+          }
+        }
+        if (providedRest) {
+          if (!expectedRest) return false;
+          return recheck(expectedRest, providedRest);
         }
         return true;
       }
       return next();
     },
   },
+  {
+    name: "check record",
+    compare: (expectedType, providedType, next, recheck) => {
+      const expectedKind = expectedType._zod.def.type;
+      const providedKind = providedType._zod.def.type;
+      if (expectedKind === "record" && providedKind === "record") {
+        return (
+          recheck(
+            expectedType._zod.def.keyType,
+            providedType._zod.def.keyType,
+          ) &&
+          recheck(
+            expectedType._zod.def.valueType,
+            providedType._zod.def.valueType,
+          )
+        );
+      }
+      return next();
+    },
+  },
+  {
+    name: "check map",
+    compare: (expectedType, providedType, next, recheck) => {
+      const expectedKind = expectedType._zod.def.type;
+      const providedKind = providedType._zod.def.type;
+      if (expectedKind === "map" && providedKind === "map") {
+        return (
+          recheck(
+            expectedType._zod.def.keyType,
+            providedType._zod.def.keyType,
+          ) &&
+          recheck(
+            expectedType._zod.def.valueType,
+            providedType._zod.def.valueType,
+          )
+        );
+      }
+      return next();
+    },
+  },
+  {
+    name: "check set",
+    compare: (expectedType, providedType, next, recheck) => {
+      const expectedKind = expectedType._zod.def.type;
+      const providedKind = providedType._zod.def.type;
+      if (expectedKind === "set" && providedKind === "set") {
+        return recheck(
+          expectedType._zod.def.valueType,
+          providedType._zod.def.valueType,
+        );
+      }
+      return next();
+    },
+  },
+  {
+    name: "final fallback",
+    compare: () => false,
+  },
 ];
 
 /**
- * Check if a the higherType matches the lowerType
+ * Check whether `providedType` is assignable to `expectedType`.
  *
- * @deprecated This a unstable API and still in development
+ * Returns true when `providedType <= expectedType`, i.e. every value accepted by
+ * `providedType` can be used where `expectedType` is expected.
  *
- * @param higherType The looser type
- * @param lowerType The stricter type
+ * @experimental This API is unstable and still in development.
+ *
+ * @param expectedType The wider/supertype schema.
+ * @param providedType The narrower/subtype schema.
  *
  * @example
  * ```ts
  * isCompatibleType(z.string(), z.string()); // true
  *
  * isCompatibleType(
+ *   z.object({ name: z.string() }),
  *   z.object({ name: z.string(), other: z.number() }),
- *   z.object({ name: z.string() })
  * );
  * // true
  * ```

--- a/src/zod4/is-compatible-type.ts
+++ b/src/zod4/is-compatible-type.ts
@@ -29,6 +29,10 @@ const schemaAcceptsUndefined = (schema: $ZodType): boolean => {
     return true;
   }
 
+  if (def.type === "literal") {
+    return def.values.includes(undefined);
+  }
+
   if (def.type === "optional") {
     return true;
   }
@@ -55,6 +59,10 @@ const schemaAcceptsNull = (schema: $ZodType): boolean => {
     return true;
   }
 
+  if (def.type === "literal") {
+    return def.values.includes(null);
+  }
+
   if (def.type === "optional") {
     const innerType = getInnerType(schema);
     return innerType ? schemaAcceptsNull(innerType) : false;
@@ -73,6 +81,14 @@ const schemaAcceptsNull = (schema: $ZodType): boolean => {
   return false;
 };
 
+/**
+ * Checks whether an object property may be omitted for the inferred TypeScript
+ * object type.
+ *
+ * This is narrower than accepting `undefined` as a value. For example,
+ * `z.union([z.string(), z.undefined()])` accepts `undefined`, but still infers a
+ * required property when used in `z.object({ key: ... })`.
+ */
 const schemaAllowsMissingObjectKey = (schema: $ZodType): boolean => {
   if (!isZodType(schema) || !isZodTypes(schema)) return false;
 
@@ -136,6 +152,33 @@ const recordKeysAreCompatible = (
     (expectedKind === "number" && providedKind === "string")
   ) {
     return true;
+  }
+
+  const expectedValues = isZodTypes(expectedKeyType)
+    ? getFiniteLiteralValues(expectedKeyType)
+    : undefined;
+  const providedValues = isZodTypes(providedKeyType)
+    ? getFiniteLiteralValues(providedKeyType)
+    : undefined;
+
+  if (expectedValues && providedValues) {
+    const providedSet = new Set(providedValues);
+    return expectedValues.every((value) => providedSet.has(value));
+  }
+
+  if (expectedValues && isZodTypes(providedKeyType)) {
+    return expectedValues.every((value) => {
+      switch (providedKind) {
+        case "string":
+          return typeof value === "string";
+        case "number":
+          return typeof value === "number";
+        case "symbol":
+          return typeof value === "symbol";
+        default:
+          return false;
+      }
+    });
   }
 
   return recheck(expectedKeyType, providedKeyType);
@@ -211,6 +254,11 @@ export const isCompatibleTypePresetRules: CompareRule[] = [
       if (expectedDef.type === "optional") {
         const innerType = getInnerType(expectedType);
         if (!innerType) return false;
+        if (providedType._zod.def.type === "union") {
+          return flatUnwrapUnion(providedType as $ZodUnion).every((option) =>
+            recheck(expectedType, option),
+          );
+        }
         return (
           recheck(innerType, providedType) ||
           schemaAcceptsUndefined(providedType)
@@ -219,6 +267,11 @@ export const isCompatibleTypePresetRules: CompareRule[] = [
       if (expectedDef.type === "nullable") {
         const innerType = getInnerType(expectedType);
         if (!innerType) return false;
+        if (providedType._zod.def.type === "union") {
+          return flatUnwrapUnion(providedType as $ZodUnion).every((option) =>
+            recheck(expectedType, option),
+          );
+        }
         return (
           recheck(innerType, providedType) || schemaAcceptsNull(providedType)
         );

--- a/src/zod4/is-compatible-type.ts
+++ b/src/zod4/is-compatible-type.ts
@@ -73,6 +73,47 @@ const schemaAcceptsNull = (schema: $ZodType): boolean => {
   return false;
 };
 
+const schemaAllowsMissingObjectKey = (schema: $ZodType): boolean => {
+  if (!isZodType(schema) || !isZodTypes(schema)) return false;
+
+  const def = schema._zod.def;
+  if (def.type === "optional") {
+    return true;
+  }
+
+  if (def.type === "nullable") {
+    const innerType = getInnerType(schema);
+    return innerType ? schemaAllowsMissingObjectKey(innerType) : false;
+  }
+
+  return false;
+};
+
+const isNumericEnumReverseEntry = (
+  entries: Record<string, unknown>,
+  key: string,
+  value: unknown,
+): boolean => {
+  if (typeof value !== "string") return false;
+  const numericKey = Number(key);
+  return Number.isFinite(numericKey) && Object.is(entries[value], numericKey);
+};
+
+const getEnumValues = (
+  entries: Record<string, unknown>,
+): readonly unknown[] => {
+  const values = Object.entries(entries)
+    .filter(([key, value]) => !isNumericEnumReverseEntry(entries, key, value))
+    .map(([, value]) => value);
+  return Array.from(new Set(values));
+};
+
+/**
+ * Extracts the finite value set represented by literal and enum schemas.
+ *
+ * These values can be compared with subset logic before falling back to broader
+ * kind rules.
+ */
 const getFiniteLiteralValues = (
   schema: $ZodTypes,
 ): readonly unknown[] | undefined => {
@@ -81,7 +122,7 @@ const getFiniteLiteralValues = (
     return def.values as readonly unknown[];
   }
   if (def.type === "enum") {
-    return Object.values(def.entries as Record<string, unknown>);
+    return getEnumValues(def.entries as Record<string, unknown>);
   }
   return undefined;
 };
@@ -94,7 +135,8 @@ const primitiveKindAcceptsValue = (
     case "string":
       return typeof value === "string";
     case "number":
-      return typeof value === "number" && !Number.isNaN(value);
+    case "nan":
+      return typeof value === "number";
     case "bigint":
       return typeof value === "bigint";
     case "boolean":
@@ -106,11 +148,45 @@ const primitiveKindAcceptsValue = (
       return value === undefined;
     case "null":
       return value === null;
-    case "nan":
-      return typeof value === "number" && Number.isNaN(value);
     default:
       return false;
   }
+};
+
+const primitiveKindsAreCompatible = (
+  expectedKind: $ZodTypes["_zod"]["def"]["type"],
+  providedKind: $ZodTypes["_zod"]["def"]["type"],
+): boolean | undefined => {
+  if (expectedKind === "void" && providedKind === "undefined") {
+    return true;
+  }
+
+  if (
+    (expectedKind === "number" || expectedKind === "nan") &&
+    (providedKind === "number" || providedKind === "nan")
+  ) {
+    return true;
+  }
+
+  return undefined;
+};
+
+const recordKeysAreCompatible = (
+  expectedKeyType: $ZodType,
+  providedKeyType: $ZodType,
+  recheck: (expectedType: $ZodType, providedType: $ZodType) => boolean,
+): boolean => {
+  const expectedKind = expectedKeyType._zod.def.type;
+  const providedKind = providedKeyType._zod.def.type;
+
+  if (
+    (expectedKind === "string" && providedKind === "number") ||
+    (expectedKind === "number" && providedKind === "string")
+  ) {
+    return true;
+  }
+
+  return recheck(expectedKeyType, providedKeyType);
 };
 
 export const isCompatibleTypePresetRules: CompareRule[] = [
@@ -251,6 +327,16 @@ export const isCompatibleTypePresetRules: CompareRule[] = [
     },
   },
   {
+    name: "check primitive assignability",
+    compare: (expectedType, providedType, next) => {
+      const result = primitiveKindsAreCompatible(
+        expectedType._zod.def.type,
+        providedType._zod.def.type,
+      );
+      return result ?? next();
+    },
+  },
+  {
     name: "check array tuple cross compatibility",
     compare: (expectedType, providedType, next, recheck) => {
       const expectedKind = expectedType._zod.def.type;
@@ -295,7 +381,7 @@ export const isCompatibleTypePresetRules: CompareRule[] = [
         const providedShape = providedType._zod.def.shape;
         for (const key in expectedShape) {
           if (!(key in providedShape)) {
-            if (!schemaAcceptsUndefined(expectedShape[key])) {
+            if (!schemaAllowsMissingObjectKey(expectedShape[key])) {
               return false;
             }
             continue;
@@ -358,9 +444,10 @@ export const isCompatibleTypePresetRules: CompareRule[] = [
       const providedKind = providedType._zod.def.type;
       if (expectedKind === "record" && providedKind === "record") {
         return (
-          recheck(
+          recordKeysAreCompatible(
             expectedType._zod.def.keyType,
             providedType._zod.def.keyType,
+            recheck,
           ) &&
           recheck(
             expectedType._zod.def.valueType,

--- a/src/zod4/is-compatible-type.ts
+++ b/src/zod4/is-compatible-type.ts
@@ -89,21 +89,17 @@ const schemaAllowsMissingObjectKey = (schema: $ZodType): boolean => {
   return false;
 };
 
-const isNumericEnumReverseEntry = (
-  entries: Record<string, unknown>,
-  key: string,
-  value: unknown,
-): boolean => {
-  if (typeof value !== "string") return false;
-  const numericKey = Number(key);
-  return Number.isFinite(numericKey) && Object.is(entries[value], numericKey);
-};
-
 const getEnumValues = (
   entries: Record<string, unknown>,
 ): readonly unknown[] => {
   const values = Object.entries(entries)
-    .filter(([key, value]) => !isNumericEnumReverseEntry(entries, key, value))
+    .filter(([key, value]) => {
+      if (typeof value !== "string") return true;
+      const numericKey = Number(key);
+      return !(
+        Number.isFinite(numericKey) && Object.is(entries[value], numericKey)
+      );
+    })
     .map(([, value]) => value);
   return Array.from(new Set(values));
 };
@@ -119,38 +115,12 @@ const getFiniteLiteralValues = (
 ): readonly unknown[] | undefined => {
   const def = schema._zod.def;
   if (def.type === "literal") {
-    return def.values as readonly unknown[];
+    return def.values;
   }
   if (def.type === "enum") {
-    return getEnumValues(def.entries as Record<string, unknown>);
+    return getEnumValues(def.entries);
   }
   return undefined;
-};
-
-const primitiveKindAcceptsValue = (
-  primitiveKind: $ZodTypes["_zod"]["def"]["type"],
-  value: unknown,
-): boolean => {
-  switch (primitiveKind) {
-    case "string":
-      return typeof value === "string";
-    case "number":
-    case "nan":
-      return typeof value === "number";
-    case "bigint":
-      return typeof value === "bigint";
-    case "boolean":
-      return typeof value === "boolean";
-    case "symbol":
-      return typeof value === "symbol";
-    case "undefined":
-    case "void":
-      return value === undefined;
-    case "null":
-      return value === null;
-    default:
-      return false;
-  }
 };
 
 const recordKeysAreCompatible = (
@@ -286,26 +256,49 @@ export const isCompatibleTypePresetRules: CompareRule[] = [
     },
   },
   {
-    name: "check finite literal values",
+    name: "check finite literal subset",
     compare: (expectedType, providedType, next) => {
       const expectedValues = getFiniteLiteralValues(expectedType);
       const providedValues = getFiniteLiteralValues(providedType);
-      if (!expectedValues && providedValues) {
-        const expectedKind = expectedType._zod.def.type;
-        if (
-          providedValues.every((value) =>
-            primitiveKindAcceptsValue(expectedKind, value),
-          )
-        ) {
-          return true;
+
+      if (!expectedValues || !providedValues) {
+        return next();
+      }
+
+      const expectedSet = new Set(expectedValues);
+      return providedValues.every((value) => expectedSet.has(value));
+    },
+  },
+  {
+    name: "check finite literal to primitive",
+    compare: (expectedType, providedType, next) => {
+      const expectedValues = getFiniteLiteralValues(expectedType);
+      const providedValues = getFiniteLiteralValues(providedType);
+      if (expectedValues || !providedValues) return next();
+
+      const expectedKind = expectedType._zod.def.type;
+      return providedValues.every((value) => {
+        switch (expectedKind) {
+          case "string":
+            return typeof value === "string";
+          case "number":
+          case "nan":
+            return typeof value === "number";
+          case "bigint":
+            return typeof value === "bigint";
+          case "boolean":
+            return typeof value === "boolean";
+          case "symbol":
+            return typeof value === "symbol";
+          case "undefined":
+          case "void":
+            return value === undefined;
+          case "null":
+            return value === null;
+          default:
+            return false;
         }
-      }
-      if (expectedValues || providedValues) {
-        if (!expectedValues || !providedValues) return next();
-        const expectedSet = new Set(expectedValues);
-        return providedValues.every((value) => expectedSet.has(value));
-      }
-      return next();
+      });
     },
   },
   {

--- a/src/zod4/is-compatible-type.ts
+++ b/src/zod4/is-compatible-type.ts
@@ -4,8 +4,6 @@ import { isSameType } from "./is-same-type.ts";
 import type { CompareRule } from "./types.ts";
 import { flatUnwrapUnion, isZodType, isZodTypes } from "./utils.ts";
 
-type NullishKind = "undefined" | "null";
-
 const getInnerType = (schema: $ZodTypes): $ZodTypes | undefined => {
   const def = schema._zod.def;
   if (
@@ -19,15 +17,12 @@ const getInnerType = (schema: $ZodTypes): $ZodTypes | undefined => {
   return undefined;
 };
 
-const schemaAcceptsNullishKind = (
-  schema: $ZodType,
-  nullishKind: NullishKind,
-): boolean => {
+const schemaAcceptsUndefined = (schema: $ZodType): boolean => {
   if (!isZodType(schema) || !isZodTypes(schema)) return false;
 
   const def = schema._zod.def;
   if (
-    def.type === nullishKind ||
+    def.type === "undefined" ||
     def.type === "any" ||
     def.type === "unknown"
   ) {
@@ -35,20 +30,43 @@ const schemaAcceptsNullishKind = (
   }
 
   if (def.type === "optional") {
-    if (nullishKind === "undefined") return true;
-    const innerType = getInnerType(schema);
-    return innerType ? schemaAcceptsNullishKind(innerType, nullishKind) : false;
+    return true;
   }
 
   if (def.type === "nullable") {
-    if (nullishKind === "null") return true;
     const innerType = getInnerType(schema);
-    return innerType ? schemaAcceptsNullishKind(innerType, nullishKind) : false;
+    return innerType ? schemaAcceptsUndefined(innerType) : false;
   }
 
   if (def.type === "union") {
     return flatUnwrapUnion(schema as $ZodUnion).some((option) =>
-      schemaAcceptsNullishKind(option, nullishKind),
+      schemaAcceptsUndefined(option),
+    );
+  }
+
+  return false;
+};
+
+const schemaAcceptsNull = (schema: $ZodType): boolean => {
+  if (!isZodType(schema) || !isZodTypes(schema)) return false;
+
+  const def = schema._zod.def;
+  if (def.type === "null" || def.type === "any" || def.type === "unknown") {
+    return true;
+  }
+
+  if (def.type === "optional") {
+    const innerType = getInnerType(schema);
+    return innerType ? schemaAcceptsNull(innerType) : false;
+  }
+
+  if (def.type === "nullable") {
+    return true;
+  }
+
+  if (def.type === "union") {
+    return flatUnwrapUnion(schema as $ZodUnion).some((option) =>
+      schemaAcceptsNull(option),
     );
   }
 
@@ -143,11 +161,14 @@ export const isCompatibleTypePresetRules: CompareRule[] = [
       if (providedDef.type === "optional" || providedDef.type === "nullable") {
         const innerType = getInnerType(providedType);
         if (!innerType) return false;
-        const primitiveKind =
-          providedDef.type === "optional" ? "undefined" : "null";
+        if (providedDef.type === "optional") {
+          return (
+            recheck(expectedType, innerType) &&
+            schemaAcceptsUndefined(expectedType)
+          );
+        }
         return (
-          recheck(expectedType, innerType) &&
-          schemaAcceptsNullishKind(expectedType, primitiveKind)
+          recheck(expectedType, innerType) && schemaAcceptsNull(expectedType)
         );
       }
       return next();
@@ -160,11 +181,14 @@ export const isCompatibleTypePresetRules: CompareRule[] = [
       if (expectedDef.type === "optional" || expectedDef.type === "nullable") {
         const innerType = getInnerType(expectedType);
         if (!innerType) return false;
-        const primitiveKind =
-          expectedDef.type === "optional" ? "undefined" : "null";
+        if (expectedDef.type === "optional") {
+          return (
+            recheck(innerType, providedType) ||
+            schemaAcceptsUndefined(providedType)
+          );
+        }
         return (
-          recheck(innerType, providedType) ||
-          schemaAcceptsNullishKind(providedType, primitiveKind)
+          recheck(innerType, providedType) || schemaAcceptsNull(providedType)
         );
       }
       return next();
@@ -267,7 +291,7 @@ export const isCompatibleTypePresetRules: CompareRule[] = [
         const providedShape = providedType._zod.def.shape;
         for (const key in expectedShape) {
           if (!(key in providedShape)) {
-            if (!schemaAcceptsNullishKind(expectedShape[key], "undefined")) {
+            if (!schemaAcceptsUndefined(expectedShape[key])) {
               return false;
             }
             continue;

--- a/src/zod4/is-compatible-type.ts
+++ b/src/zod4/is-compatible-type.ts
@@ -158,15 +158,17 @@ export const isCompatibleTypePresetRules: CompareRule[] = [
     name: "check optional/nullable on provided",
     compare: (expectedType, providedType, next, recheck) => {
       const providedDef = providedType._zod.def;
-      if (providedDef.type === "optional" || providedDef.type === "nullable") {
+      if (providedDef.type === "optional") {
         const innerType = getInnerType(providedType);
         if (!innerType) return false;
-        if (providedDef.type === "optional") {
-          return (
-            recheck(expectedType, innerType) &&
-            schemaAcceptsUndefined(expectedType)
-          );
-        }
+        return (
+          recheck(expectedType, innerType) &&
+          schemaAcceptsUndefined(expectedType)
+        );
+      }
+      if (providedDef.type === "nullable") {
+        const innerType = getInnerType(providedType);
+        if (!innerType) return false;
         return (
           recheck(expectedType, innerType) && schemaAcceptsNull(expectedType)
         );
@@ -178,15 +180,17 @@ export const isCompatibleTypePresetRules: CompareRule[] = [
     name: "check optional/nullable on expected",
     compare: (expectedType, providedType, next, recheck) => {
       const expectedDef = expectedType._zod.def;
-      if (expectedDef.type === "optional" || expectedDef.type === "nullable") {
+      if (expectedDef.type === "optional") {
         const innerType = getInnerType(expectedType);
         if (!innerType) return false;
-        if (expectedDef.type === "optional") {
-          return (
-            recheck(innerType, providedType) ||
-            schemaAcceptsUndefined(providedType)
-          );
-        }
+        return (
+          recheck(innerType, providedType) ||
+          schemaAcceptsUndefined(providedType)
+        );
+      }
+      if (expectedDef.type === "nullable") {
+        const innerType = getInnerType(expectedType);
+        if (!innerType) return false;
         return (
           recheck(innerType, providedType) || schemaAcceptsNull(providedType)
         );


### PR DESCRIPTION
## Summary
- Keep the public isCompatibleType name and document it as isCompatibleType(expectedType, providedType)
- Align compatibility rules around providedType <= expectedType
- Add coverage for wrappers, top/bottom/any, object optional keys, tuple/array, unions, record/map/set, and enum/literal assignability

## Verification
- pnpm vitest run
- pnpm run build
- pnpm exec prettier --check README.md src/zod4/is-compatible-type.ts src/zod4/__tests__/is-compatible-type.test.ts

Note: pnpm run typeCheck is blocked locally by untracked src/__tests__/playground.test.ts unused variable fn; no tracked type errors remain.