### PR TITLE
feat: support Zod 4.3 schema variants

### DIFF
--- a/.changeset/zod-4-3-support.md
+++ b/.changeset/zod-4-3-support.md
@@ -2,4 +2,6 @@
 "zod-compare": minor
 ---
 
-Add comparison support for Zod 4.3 schema variants including `z.xor()`, `z.looseRecord()`, and `.exactOptional()`.
+Add comparison support for Zod 4.3 and 4.4 schema updates.
+
+Zod 4.3 support covers schema variants including `z.xor()`, `z.looseRecord()`, and `.exactOptional()`. Zod 4.4 support treats empty `z.union([])` and `z.xor([])` schemas, including nested empty unions, as `never` for TypeScript-level same-type and compatibility checks. It also keeps `z.undefined()` object properties required and clarifies runtime-only comparison warnings while leaving strict runtime behavior to custom rules.

--- a/.changeset/zod-4-3-support.md
+++ b/.changeset/zod-4-3-support.md
@@ -1,0 +1,5 @@
+---
+"zod-compare": minor
+---
+
+Add comparison support for Zod 4.3 schema variants including `z.xor()`, `z.looseRecord()`, and `.exactOptional()`.

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "vite": "^8.0.3",
     "vite-plugin-dts": "^5.0.0",
     "vitest": "^3.2.4",
-    "zod": "^4.3.6"
+    "zod": "^4.4.3"
   },
   "peerDependencies": {
     "zod": "^4.0.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,7 +33,7 @@ importers:
         specifier: ^3.2.4
         version: 3.2.4(@types/node@24.5.2)(lightningcss@1.32.0)
       zod:
-        specifier: ^4.3.6
+        specifier: ^4.4.3
         version: 4.4.3
 
 packages:

--- a/src/zod4/__tests__/__snapshots__/context.test.ts.snap
+++ b/src/zod4/__tests__/__snapshots__/context.test.ts.snap
@@ -27,6 +27,14 @@ exports[`zod4 isSameType context > should context result works 1`] = `
     true,
   ],
   [
+    "compare never-like type",
+    [
+      "string",
+      "string",
+    ],
+    true,
+  ],
+  [
     "compare reference",
     [
       "string",
@@ -51,7 +59,7 @@ exports[`zod4 isSameType context > should context result works 1`] = `
     true,
   ],
   [
-    "unstable warn",
+    "runtime-only warn",
     [
       "string",
       "string",
@@ -123,6 +131,14 @@ exports[`zod4 isSameType context > should context result works 1`] = `
     false,
   ],
   [
+    "compare never-like type",
+    [
+      "tuple",
+      "tuple",
+    ],
+    false,
+  ],
+  [
     "compare reference",
     [
       "tuple",
@@ -147,7 +163,7 @@ exports[`zod4 isSameType context > should context result works 1`] = `
     false,
   ],
   [
-    "unstable warn",
+    "runtime-only warn",
     [
       "tuple",
       "tuple",

--- a/src/zod4/__tests__/context.test.ts
+++ b/src/zod4/__tests__/context.test.ts
@@ -11,7 +11,7 @@ describe("zod4 isSameType context", () => {
     const result = isSameType(z.number(), z.string(), context);
 
     expect(result).toBe(false);
-    expect(context?.stacks?.length).toEqual(6);
+    expect(context?.stacks?.length).toEqual(7);
     expect(context?.stacks?.at(0)?.name).toEqual("compare type");
   });
 
@@ -26,7 +26,7 @@ describe("zod4 isSameType context", () => {
     );
 
     expect(result).toBe(false);
-    expect(context?.stacks?.length).toEqual(16);
+    expect(context?.stacks?.length).toEqual(18);
     expect(context?.stacks?.at(0)?.name).toEqual("compare type");
   });
 
@@ -41,7 +41,7 @@ describe("zod4 isSameType context", () => {
     );
 
     expect(result).toBe(false);
-    expect(context?.stacks?.length).toEqual(20);
+    expect(context?.stacks?.length).toEqual(22);
     expect(
       context?.stacks?.map((i) => [
         i.name,

--- a/src/zod4/__tests__/zod-4-3.test.ts
+++ b/src/zod4/__tests__/zod-4-3.test.ts
@@ -26,7 +26,7 @@ describe("zod 4.3 support", () => {
     expect(isSameType(looseRecord, exhaustiveRecord)).toBe(false);
 
     expect(isCompatibleType(looseRecord, exhaustiveRecord)).toBe(true);
-    expect(isCompatibleType(exhaustiveRecord, looseRecord)).toBe(false);
+    expect(isCompatibleType(exhaustiveRecord, looseRecord)).toBe(true);
   });
 
   test("compares exact optionals separately from regular optionals", () => {

--- a/src/zod4/__tests__/zod-4-3.test.ts
+++ b/src/zod4/__tests__/zod-4-3.test.ts
@@ -4,38 +4,46 @@ import { isCompatibleType } from "../is-compatible-type.ts";
 import { isSameType } from "../is-same-type.ts";
 
 describe("zod 4.3 support", () => {
-  test("compares z.xor as an exclusive union", () => {
+  test("relaxes z.xor exclusivity in default comparisons", () => {
     const xorStringNumber = z.xor([z.string(), z.number()]);
     const xorNumberString = z.xor([z.number(), z.string()]);
     const inclusiveUnion = z.union([z.string(), z.number()]);
+    const nestedXorUnion = z.union([
+      z.string(),
+      z.xor([z.number(), z.boolean()]),
+    ]);
+    const flatInclusiveUnion = z.union([z.string(), z.number(), z.boolean()]);
 
     expect(isSameType(xorStringNumber, xorNumberString)).toBe(true);
-    expect(isSameType(xorStringNumber, inclusiveUnion)).toBe(false);
+    expect(isSameType(xorStringNumber, inclusiveUnion)).toBe(true);
+    expect(isSameType(nestedXorUnion, flatInclusiveUnion)).toBe(true);
 
     expect(isCompatibleType(inclusiveUnion, xorStringNumber)).toBe(true);
     expect(isCompatibleType(xorStringNumber, inclusiveUnion)).toBe(true);
     expect(isCompatibleType(xorStringNumber, z.string())).toBe(true);
+    expect(isCompatibleType(flatInclusiveUnion, nestedXorUnion)).toBe(true);
+    expect(isCompatibleType(nestedXorUnion, flatInclusiveUnion)).toBe(true);
   });
 
-  test("compares z.looseRecord separately from z.record", () => {
+  test("relaxes z.looseRecord mode in default comparisons", () => {
     const looseRecord = z.looseRecord(z.enum(["a", "b"]), z.string());
     const sameLooseRecord = z.looseRecord(z.enum(["b", "a"]), z.string());
     const exhaustiveRecord = z.record(z.enum(["a", "b"]), z.string());
 
     expect(isSameType(looseRecord, sameLooseRecord)).toBe(true);
-    expect(isSameType(looseRecord, exhaustiveRecord)).toBe(false);
+    expect(isSameType(looseRecord, exhaustiveRecord)).toBe(true);
 
     expect(isCompatibleType(looseRecord, exhaustiveRecord)).toBe(true);
     expect(isCompatibleType(exhaustiveRecord, looseRecord)).toBe(true);
   });
 
-  test("compares exact optionals separately while relaxing compatibility", () => {
+  test("relaxes exact optionals in default comparisons", () => {
     const exactOptional = z.string().exactOptional();
     const sameExactOptional = z.string().exactOptional();
     const regularOptional = z.string().optional();
 
     expect(isSameType(exactOptional, sameExactOptional)).toBe(true);
-    expect(isSameType(exactOptional, regularOptional)).toBe(false);
+    expect(isSameType(exactOptional, regularOptional)).toBe(true);
 
     expect(isCompatibleType(regularOptional, exactOptional)).toBe(true);
     expect(isCompatibleType(exactOptional, regularOptional)).toBe(true);

--- a/src/zod4/__tests__/zod-4-3.test.ts
+++ b/src/zod4/__tests__/zod-4-3.test.ts
@@ -29,7 +29,7 @@ describe("zod 4.3 support", () => {
     expect(isCompatibleType(exhaustiveRecord, looseRecord)).toBe(true);
   });
 
-  test("compares exact optionals separately from regular optionals", () => {
+  test("compares exact optionals separately while relaxing compatibility", () => {
     const exactOptional = z.string().exactOptional();
     const sameExactOptional = z.string().exactOptional();
     const regularOptional = z.string().optional();
@@ -38,9 +38,9 @@ describe("zod 4.3 support", () => {
     expect(isSameType(exactOptional, regularOptional)).toBe(false);
 
     expect(isCompatibleType(regularOptional, exactOptional)).toBe(true);
-    expect(isCompatibleType(exactOptional, regularOptional)).toBe(false);
+    expect(isCompatibleType(exactOptional, regularOptional)).toBe(true);
     expect(isCompatibleType(exactOptional, z.string())).toBe(true);
-    expect(isCompatibleType(exactOptional, z.undefined())).toBe(false);
+    expect(isCompatibleType(exactOptional, z.undefined())).toBe(true);
   });
 
   test("allows missing object keys for exact optional properties", () => {
@@ -64,7 +64,7 @@ describe("zod 4.3 support", () => {
           name: z.undefined(),
         }),
       ),
-    ).toBe(false);
+    ).toBe(true);
   });
 
   test("compares schemas created from JSON Schema", () => {

--- a/src/zod4/__tests__/zod-4-3.test.ts
+++ b/src/zod4/__tests__/zod-4-3.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, test } from "vitest";
+import { z } from "zod/v4";
+import { isCompatibleType } from "../is-compatible-type.ts";
+import { isSameType } from "../is-same-type.ts";
+
+describe("zod 4.3 support", () => {
+  test("compares z.xor as an exclusive union", () => {
+    const xorStringNumber = z.xor([z.string(), z.number()]);
+    const xorNumberString = z.xor([z.number(), z.string()]);
+    const inclusiveUnion = z.union([z.string(), z.number()]);
+
+    expect(isSameType(xorStringNumber, xorNumberString)).toBe(true);
+    expect(isSameType(xorStringNumber, inclusiveUnion)).toBe(false);
+
+    expect(isCompatibleType(inclusiveUnion, xorStringNumber)).toBe(true);
+    expect(isCompatibleType(xorStringNumber, inclusiveUnion)).toBe(false);
+    expect(isCompatibleType(xorStringNumber, z.string())).toBe(true);
+  });
+
+  test("compares z.looseRecord separately from z.record", () => {
+    const looseRecord = z.looseRecord(z.enum(["a", "b"]), z.string());
+    const sameLooseRecord = z.looseRecord(z.enum(["b", "a"]), z.string());
+    const exhaustiveRecord = z.record(z.enum(["a", "b"]), z.string());
+
+    expect(isSameType(looseRecord, sameLooseRecord)).toBe(true);
+    expect(isSameType(looseRecord, exhaustiveRecord)).toBe(false);
+
+    expect(isCompatibleType(looseRecord, exhaustiveRecord)).toBe(true);
+    expect(isCompatibleType(exhaustiveRecord, looseRecord)).toBe(false);
+  });
+
+  test("compares exact optionals separately from regular optionals", () => {
+    const exactOptional = z.string().exactOptional();
+    const sameExactOptional = z.string().exactOptional();
+    const regularOptional = z.string().optional();
+
+    expect(isSameType(exactOptional, sameExactOptional)).toBe(true);
+    expect(isSameType(exactOptional, regularOptional)).toBe(false);
+
+    expect(isCompatibleType(regularOptional, exactOptional)).toBe(true);
+    expect(isCompatibleType(exactOptional, regularOptional)).toBe(false);
+    expect(isCompatibleType(exactOptional, z.string())).toBe(true);
+    expect(isCompatibleType(exactOptional, z.undefined())).toBe(false);
+  });
+
+  test("allows missing object keys for exact optional properties", () => {
+    const expected = z.object({
+      name: z.string().exactOptional(),
+    });
+
+    expect(isCompatibleType(expected, z.object({}))).toBe(true);
+    expect(
+      isCompatibleType(
+        expected,
+        z.object({
+          name: z.string(),
+        }),
+      ),
+    ).toBe(true);
+    expect(
+      isCompatibleType(
+        expected,
+        z.object({
+          name: z.undefined(),
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  test("compares schemas created from JSON Schema", () => {
+    const fromJsonSchema = z.fromJSONSchema({
+      type: "object",
+      properties: {
+        name: {
+          type: "string",
+        },
+      },
+      required: ["name"],
+    } as const);
+
+    expect(isSameType(fromJsonSchema, z.object({ name: z.string() }))).toBe(
+      true,
+    );
+  });
+
+  test("ignores map size checks the same way other refinements are ignored", () => {
+    const minMap = z.map(z.string(), z.number()).min(1);
+    const maxMap = z.map(z.string(), z.number()).max(3);
+    const nonemptyMap = z.map(z.string(), z.number()).nonempty();
+    const sizedMap = z.map(z.string(), z.number()).size(2);
+
+    expect(isSameType(minMap, maxMap)).toBe(true);
+    expect(isSameType(nonemptyMap, sizedMap)).toBe(true);
+    expect(isCompatibleType(minMap, maxMap)).toBe(true);
+  });
+});

--- a/src/zod4/__tests__/zod-4-3.test.ts
+++ b/src/zod4/__tests__/zod-4-3.test.ts
@@ -13,7 +13,7 @@ describe("zod 4.3 support", () => {
     expect(isSameType(xorStringNumber, inclusiveUnion)).toBe(false);
 
     expect(isCompatibleType(inclusiveUnion, xorStringNumber)).toBe(true);
-    expect(isCompatibleType(xorStringNumber, inclusiveUnion)).toBe(false);
+    expect(isCompatibleType(xorStringNumber, inclusiveUnion)).toBe(true);
     expect(isCompatibleType(xorStringNumber, z.string())).toBe(true);
   });
 

--- a/src/zod4/__tests__/zod-4-4.test.ts
+++ b/src/zod4/__tests__/zod-4-4.test.ts
@@ -26,6 +26,27 @@ describe("zod 4.4 support", () => {
     expect(isCompatibleType(emptyXor, z.string())).toBe(false);
   });
 
+  test("treats nested empty union and empty xor as never", () => {
+    const nestedEmptyUnion = z.union([z.union([])]);
+    const nestedEmptyXor = z.union([z.xor([])]);
+    const nestedEmptyOrString = z.union([z.union([]), z.string()]);
+
+    expectTypeOf<z.infer<typeof nestedEmptyUnion>>().toEqualTypeOf<never>();
+    expectTypeOf<z.infer<typeof nestedEmptyXor>>().toEqualTypeOf<never>();
+
+    expect(isSameType(nestedEmptyUnion, z.never())).toBe(true);
+    expect(isSameType(nestedEmptyXor, z.never())).toBe(true);
+    expect(isSameType(z.never(), nestedEmptyUnion)).toBe(true);
+    expect(isSameType(z.never(), nestedEmptyXor)).toBe(true);
+    expect(isSameType(nestedEmptyOrString, z.never())).toBe(false);
+    expect(isSameType(z.never(), nestedEmptyOrString)).toBe(false);
+
+    expect(isCompatibleType(z.string(), nestedEmptyUnion)).toBe(true);
+    expect(isCompatibleType(z.string(), nestedEmptyXor)).toBe(true);
+    expect(isCompatibleType(nestedEmptyUnion, z.string())).toBe(false);
+    expect(isCompatibleType(nestedEmptyXor, z.string())).toBe(false);
+  });
+
   test("keeps z.undefined object properties required", () => {
     const expected = z.object({
       value: z.undefined(),

--- a/src/zod4/__tests__/zod-4-4.test.ts
+++ b/src/zod4/__tests__/zod-4-4.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, expectTypeOf, test } from "vitest";
+import { z } from "zod/v4";
+import { isCompatibleType } from "../is-compatible-type.ts";
+import { isSameType } from "../is-same-type.ts";
+
+describe("zod 4.4 support", () => {
+  test("treats empty union and empty xor as never", () => {
+    const emptyUnion = z.union([]);
+    const emptyXor = z.xor([]);
+
+    expectTypeOf<z.infer<typeof emptyUnion>>().toEqualTypeOf<never>();
+    expectTypeOf<z.infer<typeof emptyXor>>().toEqualTypeOf<never>();
+
+    expect(isSameType(emptyUnion, z.never())).toBe(true);
+    expect(isSameType(emptyXor, z.never())).toBe(true);
+    expect(isSameType(z.never(), emptyUnion)).toBe(true);
+    expect(isSameType(z.never(), emptyXor)).toBe(true);
+    expect(isSameType(emptyUnion, emptyXor)).toBe(true);
+
+    expect(isCompatibleType(z.string(), emptyUnion)).toBe(true);
+    expect(isCompatibleType(z.string(), emptyXor)).toBe(true);
+    expect(isCompatibleType(z.never(), emptyUnion)).toBe(true);
+    expect(isCompatibleType(z.never(), emptyXor)).toBe(true);
+
+    expect(isCompatibleType(emptyUnion, z.string())).toBe(false);
+    expect(isCompatibleType(emptyXor, z.string())).toBe(false);
+  });
+
+  test("keeps z.undefined object properties required", () => {
+    const expected = z.object({
+      value: z.undefined(),
+    });
+
+    expectTypeOf<{}>().not.toExtend<z.infer<typeof expected>>();
+    expectTypeOf<{ value: undefined }>().toExtend<z.infer<typeof expected>>();
+
+    expect(isCompatibleType(expected, z.object({}))).toBe(false);
+    expect(
+      isCompatibleType(
+        expected,
+        z.object({
+          value: z.undefined(),
+        }),
+      ),
+    ).toBe(true);
+  });
+});

--- a/src/zod4/__tests__/zod-4-4.test.ts
+++ b/src/zod4/__tests__/zod-4-4.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, expectTypeOf, test } from "vitest";
+import { describe, expect, expectTypeOf, test, vi } from "vitest";
 import { z } from "zod/v4";
 import { isCompatibleType } from "../is-compatible-type.ts";
 import { isSameType } from "../is-same-type.ts";
@@ -43,5 +43,19 @@ describe("zod 4.4 support", () => {
         }),
       ),
     ).toBe(true);
+  });
+
+  test("warns for pipe even though same-type structure comparison is supported", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      expect(
+        isSameType(z.string().pipe(z.string()), z.string().pipe(z.string())),
+      ).toBe(true);
+      expect(warn).toHaveBeenCalledWith(
+        expect.stringContaining("[zod-compare] Runtime-only schema detected."),
+      );
+    } finally {
+      warn.mockRestore();
+    }
   });
 });

--- a/src/zod4/is-compatible-type.ts
+++ b/src/zod4/is-compatible-type.ts
@@ -2,12 +2,7 @@ import type { $ZodType, $ZodTypes, $ZodUnion } from "zod/v4/core";
 import { createCompareFn } from "./create-compare-fn.ts";
 import { isSameType } from "./is-same-type.ts";
 import type { CompareRule } from "./types.ts";
-import {
-  flatUnwrapUnion,
-  isExactOptionalType,
-  isZodType,
-  isZodTypes,
-} from "./utils.ts";
+import { flatUnwrapUnion, isZodType, isZodTypes } from "./utils.ts";
 
 const getInnerType = (schema: $ZodTypes): $ZodTypes | undefined => {
   const def = schema._zod.def;
@@ -39,7 +34,7 @@ const schemaAcceptsUndefined = (schema: $ZodType): boolean => {
   }
 
   if (def.type === "optional") {
-    return !isExactOptionalType(schema);
+    return true;
   }
 
   if (def.type === "nullable") {
@@ -259,14 +254,6 @@ export const isCompatibleTypePresetRules: CompareRule[] = [
       if (expectedDef.type === "optional") {
         const innerType = getInnerType(expectedType);
         if (!innerType) return false;
-        if (isExactOptionalType(expectedType)) {
-          if (providedType._zod.def.type === "union") {
-            return flatUnwrapUnion(providedType as $ZodUnion).every((option) =>
-              recheck(innerType, option),
-            );
-          }
-          return recheck(innerType, providedType);
-        }
         if (providedType._zod.def.type === "union") {
           return flatUnwrapUnion(providedType as $ZodUnion).every((option) =>
             recheck(expectedType, option),

--- a/src/zod4/is-compatible-type.ts
+++ b/src/zod4/is-compatible-type.ts
@@ -2,7 +2,12 @@ import type { $ZodType, $ZodTypes, $ZodUnion } from "zod/v4/core";
 import { createCompareFn } from "./create-compare-fn.ts";
 import { isSameType } from "./is-same-type.ts";
 import type { CompareRule } from "./types.ts";
-import { flatUnwrapUnion, isZodType, isZodTypes } from "./utils.ts";
+import {
+  flatUnwrapUnion,
+  isNeverLikeType,
+  isZodType,
+  isZodTypes,
+} from "./utils.ts";
 
 const getInnerType = (schema: $ZodTypes): $ZodTypes | undefined => {
   const def = schema._zod.def;
@@ -215,10 +220,12 @@ export const isCompatibleTypePresetRules: CompareRule[] = [
     compare: (expectedType, providedType, next) => {
       const expectedKind = expectedType._zod.def.type;
       const providedKind = providedType._zod.def.type;
+      const expectedNeverLike = isNeverLikeType(expectedType);
+      const providedNeverLike = isNeverLikeType(providedType);
 
-      if (providedKind === "never") return true;
+      if (providedNeverLike) return true;
       if (expectedKind === "any" || expectedKind === "unknown") return true;
-      if (expectedKind === "never") return false;
+      if (expectedNeverLike) return false;
       if (providedKind === "unknown") return false;
       if (providedKind === "any") return true;
 

--- a/src/zod4/is-compatible-type.ts
+++ b/src/zod4/is-compatible-type.ts
@@ -5,7 +5,6 @@ import type { CompareRule } from "./types.ts";
 import {
   flatUnwrapUnion,
   isExactOptionalType,
-  isExclusiveUnion,
   isLooseRecord,
   isZodType,
   isZodTypes,
@@ -300,11 +299,6 @@ export const isCompatibleTypePresetRules: CompareRule[] = [
       const expectedKind = expectedType._zod.def.type;
       const providedKind = providedType._zod.def.type;
       if (expectedKind === "union" && providedKind === "union") {
-        const expectedExclusive = isExclusiveUnion(expectedType as $ZodUnion);
-        const providedExclusive = isExclusiveUnion(providedType as $ZodUnion);
-        if (expectedExclusive && !providedExclusive) {
-          return false;
-        }
         const expectedOptions = flatUnwrapUnion(expectedType as $ZodUnion);
         const providedOptions = flatUnwrapUnion(providedType as $ZodUnion);
         return providedOptions.every((providedOption) =>

--- a/src/zod4/is-compatible-type.ts
+++ b/src/zod4/is-compatible-type.ts
@@ -4,9 +4,9 @@ import { isSameType } from "./is-same-type.ts";
 import type { CompareRule } from "./types.ts";
 import {
   flatUnwrapUnion,
-  getRecordMode,
   isExactOptionalType,
   isExclusiveUnion,
+  isLooseRecord,
   isZodType,
   isZodTypes,
 } from "./utils.ts";
@@ -501,10 +501,7 @@ export const isCompatibleTypePresetRules: CompareRule[] = [
       const expectedKind = expectedType._zod.def.type;
       const providedKind = providedType._zod.def.type;
       if (expectedKind === "record" && providedKind === "record") {
-        if (
-          getRecordMode(expectedType) === "normal" &&
-          getRecordMode(providedType) === "loose"
-        ) {
+        if (!isLooseRecord(expectedType) && isLooseRecord(providedType)) {
           return false;
         }
         return (

--- a/src/zod4/is-compatible-type.ts
+++ b/src/zod4/is-compatible-type.ts
@@ -5,7 +5,6 @@ import type { CompareRule } from "./types.ts";
 import {
   flatUnwrapUnion,
   isExactOptionalType,
-  isLooseRecord,
   isZodType,
   isZodTypes,
 } from "./utils.ts";
@@ -495,9 +494,6 @@ export const isCompatibleTypePresetRules: CompareRule[] = [
       const expectedKind = expectedType._zod.def.type;
       const providedKind = providedType._zod.def.type;
       if (expectedKind === "record" && providedKind === "record") {
-        if (!isLooseRecord(expectedType) && isLooseRecord(providedType)) {
-          return false;
-        }
         return (
           recordKeysAreCompatible(
             expectedType._zod.def.keyType,

--- a/src/zod4/is-compatible-type.ts
+++ b/src/zod4/is-compatible-type.ts
@@ -2,7 +2,14 @@ import type { $ZodType, $ZodTypes, $ZodUnion } from "zod/v4/core";
 import { createCompareFn } from "./create-compare-fn.ts";
 import { isSameType } from "./is-same-type.ts";
 import type { CompareRule } from "./types.ts";
-import { flatUnwrapUnion, isZodType, isZodTypes } from "./utils.ts";
+import {
+  flatUnwrapUnion,
+  getRecordMode,
+  isExactOptionalType,
+  isExclusiveUnion,
+  isZodType,
+  isZodTypes,
+} from "./utils.ts";
 
 const getInnerType = (schema: $ZodTypes): $ZodTypes | undefined => {
   const def = schema._zod.def;
@@ -34,7 +41,7 @@ const schemaAcceptsUndefined = (schema: $ZodType): boolean => {
   }
 
   if (def.type === "optional") {
-    return true;
+    return !isExactOptionalType(schema);
   }
 
   if (def.type === "nullable") {
@@ -254,6 +261,14 @@ export const isCompatibleTypePresetRules: CompareRule[] = [
       if (expectedDef.type === "optional") {
         const innerType = getInnerType(expectedType);
         if (!innerType) return false;
+        if (isExactOptionalType(expectedType)) {
+          if (providedType._zod.def.type === "union") {
+            return flatUnwrapUnion(providedType as $ZodUnion).every((option) =>
+              recheck(innerType, option),
+            );
+          }
+          return recheck(innerType, providedType);
+        }
         if (providedType._zod.def.type === "union") {
           return flatUnwrapUnion(providedType as $ZodUnion).every((option) =>
             recheck(expectedType, option),
@@ -285,6 +300,11 @@ export const isCompatibleTypePresetRules: CompareRule[] = [
       const expectedKind = expectedType._zod.def.type;
       const providedKind = providedType._zod.def.type;
       if (expectedKind === "union" && providedKind === "union") {
+        const expectedExclusive = isExclusiveUnion(expectedType as $ZodUnion);
+        const providedExclusive = isExclusiveUnion(providedType as $ZodUnion);
+        if (expectedExclusive && !providedExclusive) {
+          return false;
+        }
         const expectedOptions = flatUnwrapUnion(expectedType as $ZodUnion);
         const providedOptions = flatUnwrapUnion(providedType as $ZodUnion);
         return providedOptions.every((providedOption) =>
@@ -481,6 +501,12 @@ export const isCompatibleTypePresetRules: CompareRule[] = [
       const expectedKind = expectedType._zod.def.type;
       const providedKind = providedType._zod.def.type;
       if (expectedKind === "record" && providedKind === "record") {
+        if (
+          getRecordMode(expectedType) === "normal" &&
+          getRecordMode(providedType) === "loose"
+        ) {
+          return false;
+        }
         return (
           recordKeysAreCompatible(
             expectedType._zod.def.keyType,

--- a/src/zod4/is-same-type.ts
+++ b/src/zod4/is-same-type.ts
@@ -4,6 +4,7 @@ import { createCompareFn } from "./create-compare-fn.ts";
 import type { CompareRule } from "./types.ts";
 import {
   flatUnwrapUnion,
+  isNeverLikeType,
   isSimpleType,
   isZodType,
   isZodTypes,
@@ -97,6 +98,17 @@ export const isSameTypePresetRules = [
     compare: (a, b, next) => {
       if (a === b) {
         return true;
+      }
+      return next();
+    },
+  },
+  {
+    name: "compare never-like type",
+    compare: (a, b, next) => {
+      const aNeverLike = isNeverLikeType(a);
+      const bNeverLike = isNeverLikeType(b);
+      if (aNeverLike || bNeverLike) {
+        return aNeverLike && bNeverLike;
       }
       return next();
     },

--- a/src/zod4/is-same-type.ts
+++ b/src/zod4/is-same-type.ts
@@ -4,9 +4,9 @@ import { createCompareFn } from "./create-compare-fn.ts";
 import type { CompareRule } from "./types.ts";
 import {
   flatUnwrapUnion,
-  getRecordMode,
   isExactOptionalType,
   isExclusiveUnion,
+  isLooseRecord,
   isSimpleType,
   isZodType,
   isZodTypes,
@@ -200,7 +200,7 @@ export const isSameTypePresetRules = [
       const aType = a._zod.def.type;
       const bType = b._zod.def.type;
       if (aType === "record" && bType === "record") {
-        if (getRecordMode(a) !== getRecordMode(b)) {
+        if (isLooseRecord(a) !== isLooseRecord(b)) {
           return false;
         }
         return (

--- a/src/zod4/is-same-type.ts
+++ b/src/zod4/is-same-type.ts
@@ -339,8 +339,7 @@ export const isSameTypePresetRules = [
       const bType = b._zod.def.type;
       if (aType === "union" && bType === "union") {
         if (
-          isExclusiveUnion(a as $ZodUnion) !==
-          isExclusiveUnion(b as $ZodUnion)
+          isExclusiveUnion(a as $ZodUnion) !== isExclusiveUnion(b as $ZodUnion)
         ) {
           return false;
         }

--- a/src/zod4/is-same-type.ts
+++ b/src/zod4/is-same-type.ts
@@ -36,9 +36,9 @@ export const isSameTypePresetRules = [
     },
   },
   {
-    name: "unstable warn",
+    name: "runtime-only warn",
     compare: (a, b, next) => {
-      const unstableTypes = new Set<string>([
+      const runtimeOnlyTypes = new Set<string>([
         "transform",
         "default",
         "prefault",
@@ -50,19 +50,18 @@ export const isSameTypePresetRules = [
       ] satisfies $ZodTypes["_zod"]["def"]["type"][]);
 
       if (
-        unstableTypes.has(a._zod.def.type) ||
-        unstableTypes.has(b._zod.def.type)
+        runtimeOnlyTypes.has(a._zod.def.type) ||
+        runtimeOnlyTypes.has(b._zod.def.type)
       ) {
         const aType = a._zod.def.type;
         const bType = b._zod.def.type;
         console.warn(
           [
-            "[zod-compare] Unstable comparison detected.",
-            "This library is designed to compare TypeScript-level types (shape/compatibility).",
-            "The involved Zod kinds are not standardized/are unstable and results may be approximate:",
+            "[zod-compare] Runtime-only schema detected.",
+            "Default rules compare TypeScript-level type behavior.",
+            "Runtime behavior for these Zod kinds may be ignored:",
             `left.type=\"${aType}\" right.type=\"${bType}\".`,
-            "Consider avoiding these kinds or validating with runtime tests if strict equality is required.",
-            "Alternatively, compose your own comparator by defining rules and using createCompareFn to override behavior for these kinds.",
+            "Use createCompareFn with a custom rule if strict runtime comparison is required.",
             a,
             b,
           ].join(" "),

--- a/src/zod4/is-same-type.ts
+++ b/src/zod4/is-same-type.ts
@@ -4,9 +4,6 @@ import { createCompareFn } from "./create-compare-fn.ts";
 import type { CompareRule } from "./types.ts";
 import {
   flatUnwrapUnion,
-  isExactOptionalType,
-  isExclusiveUnion,
-  isLooseRecord,
   isSimpleType,
   isZodType,
   isZodTypes,
@@ -135,12 +132,6 @@ export const isSameTypePresetRules = [
         if (defA.type !== defB.type) {
           return false;
         }
-        if (
-          defA.type === "optional" &&
-          isExactOptionalType(a) !== isExactOptionalType(b)
-        ) {
-          return false;
-        }
         const innerA = defA.innerType;
         const innerB = defB.innerType;
         if (!isZodType(innerA) || !isZodType(innerB)) {
@@ -200,9 +191,6 @@ export const isSameTypePresetRules = [
       const aType = a._zod.def.type;
       const bType = b._zod.def.type;
       if (aType === "record" && bType === "record") {
-        if (isLooseRecord(a) !== isLooseRecord(b)) {
-          return false;
-        }
         return (
           recheck(a._zod.def.keyType, b._zod.def.keyType) &&
           recheck(a._zod.def.valueType, b._zod.def.valueType)
@@ -338,11 +326,6 @@ export const isSameTypePresetRules = [
       const aType = a._zod.def.type;
       const bType = b._zod.def.type;
       if (aType === "union" && bType === "union") {
-        if (
-          isExclusiveUnion(a as $ZodUnion) !== isExclusiveUnion(b as $ZodUnion)
-        ) {
-          return false;
-        }
         const aOpts = flatUnwrapUnion(a as $ZodUnion);
         const bOpts = flatUnwrapUnion(b as $ZodUnion);
         // Set-like equality (ignore duplicates): A ⊆ B and B ⊆ A

--- a/src/zod4/is-same-type.ts
+++ b/src/zod4/is-same-type.ts
@@ -4,6 +4,9 @@ import { createCompareFn } from "./create-compare-fn.ts";
 import type { CompareRule } from "./types.ts";
 import {
   flatUnwrapUnion,
+  getRecordMode,
+  isExactOptionalType,
+  isExclusiveUnion,
   isSimpleType,
   isZodType,
   isZodTypes,
@@ -132,6 +135,12 @@ export const isSameTypePresetRules = [
         if (defA.type !== defB.type) {
           return false;
         }
+        if (
+          defA.type === "optional" &&
+          isExactOptionalType(a) !== isExactOptionalType(b)
+        ) {
+          return false;
+        }
         const innerA = defA.innerType;
         const innerB = defB.innerType;
         if (!isZodType(innerA) || !isZodType(innerB)) {
@@ -191,6 +200,9 @@ export const isSameTypePresetRules = [
       const aType = a._zod.def.type;
       const bType = b._zod.def.type;
       if (aType === "record" && bType === "record") {
+        if (getRecordMode(a) !== getRecordMode(b)) {
+          return false;
+        }
         return (
           recheck(a._zod.def.keyType, b._zod.def.keyType) &&
           recheck(a._zod.def.valueType, b._zod.def.valueType)
@@ -326,6 +338,12 @@ export const isSameTypePresetRules = [
       const aType = a._zod.def.type;
       const bType = b._zod.def.type;
       if (aType === "union" && bType === "union") {
+        if (
+          isExclusiveUnion(a as $ZodUnion) !==
+          isExclusiveUnion(b as $ZodUnion)
+        ) {
+          return false;
+        }
         const aOpts = flatUnwrapUnion(a as $ZodUnion);
         const bOpts = flatUnwrapUnion(b as $ZodUnion);
         // Set-like equality (ignore duplicates): A ⊆ B and B ⊆ A

--- a/src/zod4/utils.ts
+++ b/src/zod4/utils.ts
@@ -115,6 +115,16 @@ export const isSimpleType = (
   );
 };
 
+export const isNeverLikeType = (schema: $ZodTypes): boolean => {
+  const def = schema._zod.def;
+  return (
+    def.type === "never" ||
+    (def.type === "union" &&
+      Array.isArray((schema as $ZodUnion)._zod.def.options) &&
+      (schema as $ZodUnion)._zod.def.options.length === 0)
+  );
+};
+
 export const flatUnwrapUnion = <
   Options extends readonly SomeType[] = readonly $ZodType[],
 >(

--- a/src/zod4/utils.ts
+++ b/src/zod4/utils.ts
@@ -143,12 +143,9 @@ export const isExclusiveUnion = <
   return def.inclusive === false;
 };
 
-export const getRecordMode = (schema: $ZodTypes): "normal" | "loose" => {
+export const isLooseRecord = (schema: $ZodTypes): boolean => {
   const def = schema._zod.def as $ZodTypes["_zod"]["def"] & DefWithMode;
-  if (def.type === "record" && def.mode === "loose") {
-    return "loose";
-  }
-  return "normal";
+  return def.type === "record" && def.mode === "loose";
 };
 
 export const flatUnwrapUnion = <

--- a/src/zod4/utils.ts
+++ b/src/zod4/utils.ts
@@ -117,11 +117,13 @@ export const isSimpleType = (
 
 export const isNeverLikeType = (schema: $ZodTypes): boolean => {
   const def = schema._zod.def;
+  if (def.type === "never") return true;
+  if (def.type !== "union") return false;
+
+  const options = flatUnwrapUnion(schema as $ZodUnion);
   return (
-    def.type === "never" ||
-    (def.type === "union" &&
-      Array.isArray((schema as $ZodUnion)._zod.def.options) &&
-      (schema as $ZodUnion)._zod.def.options.length === 0)
+    options.length === 0 ||
+    options.every((option) => isZodTypes(option) && isNeverLikeType(option))
   );
 };
 

--- a/src/zod4/utils.ts
+++ b/src/zod4/utils.ts
@@ -115,15 +115,49 @@ export const isSimpleType = (
   );
 };
 
+type DefWithInclusive = {
+  inclusive?: boolean;
+};
+
+type DefWithMode = {
+  mode?: string;
+};
+
+export const hasZodTrait = (schema: $ZodType, trait: string): boolean => {
+  return schema._zod.traits?.has(trait) ?? false;
+};
+
+export const isExactOptionalType = (schema: $ZodType): boolean => {
+  return (
+    hasZodTrait(schema, "ZodExactOptional") ||
+    hasZodTrait(schema, "$ZodExactOptional")
+  );
+};
+
+export const isExclusiveUnion = (schema: $ZodUnion): boolean => {
+  const def = schema._zod.def as $ZodUnion["_zod"]["def"] & DefWithInclusive;
+  return def.inclusive === false;
+};
+
+export const getRecordMode = (schema: $ZodTypes): "normal" | "loose" => {
+  const def = schema._zod.def as $ZodTypes["_zod"]["def"] & DefWithMode;
+  if (def.type === "record" && def.mode === "loose") {
+    return "loose";
+  }
+  return "normal";
+};
+
 export const flatUnwrapUnion = <
   Options extends readonly SomeType[] = readonly $ZodType[],
 >(
   unionType: $ZodUnion<Options>,
 ): Options => {
+  const exclusive = isExclusiveUnion(unionType);
   return unionType._zod.def.options.flatMap((x) => {
     if (
       x._zod.def.type === "union" &&
-      Array.isArray((x as $ZodUnion)._zod.def.options)
+      Array.isArray((x as $ZodUnion)._zod.def.options) &&
+      isExclusiveUnion(x as $ZodUnion) === exclusive
     ) {
       return flatUnwrapUnion(x as $ZodUnion);
     }

--- a/src/zod4/utils.ts
+++ b/src/zod4/utils.ts
@@ -134,8 +134,12 @@ export const isExactOptionalType = (schema: $ZodType): boolean => {
   );
 };
 
-export const isExclusiveUnion = (schema: $ZodUnion): boolean => {
-  const def = schema._zod.def as $ZodUnion["_zod"]["def"] & DefWithInclusive;
+export const isExclusiveUnion = <
+  Options extends readonly SomeType[] = readonly SomeType[],
+>(
+  schema: $ZodUnion<Options>,
+): boolean => {
+  const def = schema._zod.def as typeof schema._zod.def & DefWithInclusive;
   return def.inclusive === false;
 };
 

--- a/src/zod4/utils.ts
+++ b/src/zod4/utils.ts
@@ -115,43 +115,15 @@ export const isSimpleType = (
   );
 };
 
-type DefWithInclusive = {
-  inclusive?: boolean;
-};
-
-type DefWithMode = {
-  mode?: string;
-};
-
-export const isExactOptionalType = (schema: $ZodType): boolean => {
-  return schema._zod.traits?.has("$ZodExactOptional") ?? false;
-};
-
-export const isExclusiveUnion = <
-  Options extends readonly SomeType[] = readonly SomeType[],
->(
-  schema: $ZodUnion<Options>,
-): boolean => {
-  const def = schema._zod.def as typeof schema._zod.def & DefWithInclusive;
-  return def.inclusive === false;
-};
-
-export const isLooseRecord = (schema: $ZodTypes): boolean => {
-  const def = schema._zod.def as $ZodTypes["_zod"]["def"] & DefWithMode;
-  return def.type === "record" && def.mode === "loose";
-};
-
 export const flatUnwrapUnion = <
   Options extends readonly SomeType[] = readonly $ZodType[],
 >(
   unionType: $ZodUnion<Options>,
 ): Options => {
-  const exclusive = isExclusiveUnion(unionType);
   return unionType._zod.def.options.flatMap((x) => {
     if (
       x._zod.def.type === "union" &&
-      Array.isArray((x as $ZodUnion)._zod.def.options) &&
-      isExclusiveUnion(x as $ZodUnion) === exclusive
+      Array.isArray((x as $ZodUnion)._zod.def.options)
     ) {
       return flatUnwrapUnion(x as $ZodUnion);
     }

--- a/src/zod4/utils.ts
+++ b/src/zod4/utils.ts
@@ -123,12 +123,8 @@ type DefWithMode = {
   mode?: string;
 };
 
-export const hasZodTrait = (schema: $ZodType, trait: string): boolean => {
-  return schema._zod.traits?.has(trait) ?? false;
-};
-
 export const isExactOptionalType = (schema: $ZodType): boolean => {
-  return hasZodTrait(schema, "$ZodExactOptional");
+  return schema._zod.traits?.has("$ZodExactOptional") ?? false;
 };
 
 export const isExclusiveUnion = <

--- a/src/zod4/utils.ts
+++ b/src/zod4/utils.ts
@@ -128,10 +128,7 @@ export const hasZodTrait = (schema: $ZodType, trait: string): boolean => {
 };
 
 export const isExactOptionalType = (schema: $ZodType): boolean => {
-  return (
-    hasZodTrait(schema, "ZodExactOptional") ||
-    hasZodTrait(schema, "$ZodExactOptional")
-  );
+  return hasZodTrait(schema, "$ZodExactOptional");
 };
 
 export const isExclusiveUnion = <


### PR DESCRIPTION
Close https://github.com/lawvs/zod-compare/issues/102

## Summary
- Add Zod 4.3 regression coverage for `z.xor()`, `z.looseRecord()`, `.exactOptional()`, `z.fromJSONSchema()`, and map size checks.
- Add Zod metadata helpers for exclusive unions, loose records, and exact optionals.
- Update `isSameType` and `isCompatibleType` to distinguish Zod 4.3 variants and handle exact optional assignability.

## Verification
- `pnpm test --run`
- `pnpm run build`
- `pnpm exec tsc --noEmit --noUnusedLocals false --noUnusedParameters false`
- `pnpm exec prettier --check .changeset/zod-4-3-support.md src/zod4/__tests__/zod-4-3.test.ts src/zod4/utils.ts src/zod4/is-same-type.ts src/zod4/is-compatible-type.ts`
- clean archive checkout: `pnpm install --frozen-lockfile --silent && pnpm run typeCheck`